### PR TITLE
Add QCDShape nuisance for all MSSM categories in et,mt

### DIFF
--- a/setup/et/unc-mssm-7TeV-08.conf
+++ b/setup/et/unc-mssm-7TeV-08.conf
@@ -12,6 +12,7 @@ CMS_htt_ttbarNorm_7TeV				lnN
 CMS_htt_WNorm_etau_nobtag_7TeV			lnN
 CMS_htt_DiBosonNorm_7TeV			lnN
 CMS_htt_QCDSyst_etau_nobtag_7TeV       		lnN
+CMS_htt_QCDShape_etau_nobtag_7TeV               shape
 CMS_htt_ZJetFakeTau_etau_nobtag_7TeV		lnN
 CMS_htt_ZLeptonFakeTau_etau_7TeV    		lnN
 #CMS_htt_ZEEShape_etau_7TeV         		shape

--- a/setup/et/unc-mssm-7TeV-08.vals
+++ b/setup/et/unc-mssm-7TeV-08.vals
@@ -13,7 +13,8 @@ eleTau_nobtag			ZTT,ZL,ZJ			CMS_htt_zttNorm_7TeV 				1.03
 eleTau_nobtag			TT				CMS_htt_ttbarNorm_7TeV				1.08
 eleTau_nobtag			VV				CMS_htt_DiBosonNorm_7TeV			1.15
 eleTau_nobtag			W				CMS_htt_WNorm_etau_nobtag_7TeV 		1.10
-eleTau_nobtag                 QCD				CMS_htt_QCDSyst_etau_nobtag_7TeV		1.10
+eleTau_nobtag                   QCD				CMS_htt_QCDSyst_etau_nobtag_7TeV		1.10
+eleTau_nobtag                   QCD				CMS_htt_QCDShape_etau_nobtag_7TeV		1.00
 eleTau_nobtag			ZJ				CMS_htt_ZJetFakeTau_etau_nobtag_7TeV      	1.20
 eleTau_nobtag			ZL				CMS_htt_ZLeptonFakeTau_etau_7TeV		1.20
 #eleTau_nobtag			ZL				CMS_htt_ZEEShape_etau_7TeV			1.00    

--- a/setup/et/unc-mssm-7TeV-09.conf
+++ b/setup/et/unc-mssm-7TeV-09.conf
@@ -15,6 +15,7 @@ CMS_htt_DiBosonNorm_7TeV		lnN
 CMS_htt_WNorm_etau_btag_7TeV		lnN
 CMS_htt_extrap_ztt_etau_btag_7TeV	lnN
 CMS_htt_QCDSyst_etau_btag_7TeV    	lnN
+CMS_htt_QCDShape_etau_btag_7TeV    	shape
 CMS_htt_ZLeptonFakeTau_etau_7TeV    	lnN
 CMS_htt_ZJetFakeTau_etau_btag_7TeV    	lnN
 #CMS_htt_ZEEShape_etau_7TeV         	shape

--- a/setup/et/unc-mssm-7TeV-09.vals
+++ b/setup/et/unc-mssm-7TeV-09.vals
@@ -20,6 +20,7 @@ eleTau_btag	 	VV	          	CMS_htt_DiBosonNorm_7TeV 		1.15
 eleTau_btag		W	          	CMS_htt_WNorm_etau_btag_7TeV 		1.30
 eleTau_btag		ZTT	          	CMS_htt_extrap_ztt_etau_btag_7TeV	1.03
 eleTau_btag     	QCD	          	CMS_htt_QCDSyst_etau_btag_7TeV		1.20
+eleTau_btag     	QCD	          	CMS_htt_QCDShape_etau_btag_7TeV		1.00
 eleTau_btag         	ZL	          	CMS_htt_ZLeptonFakeTau_etau_7TeV	1.20
 eleTau_btag         	ZJ	          	CMS_htt_ZJetFakeTau_etau_btag_7TeV	1.20
 #eleTau_btag		ZL			CMS_htt_ZEEShape_etau_7TeV		1.00    

--- a/setup/et/unc-mssm-8TeV-08.conf
+++ b/setup/et/unc-mssm-8TeV-08.conf
@@ -12,6 +12,7 @@ CMS_htt_ttbarNorm_8TeV				lnN
 CMS_htt_WNorm_etau_nobtag_8TeV			lnN
 CMS_htt_DiBosonNorm_8TeV			lnN
 CMS_htt_QCDSyst_etau_nobtag_8TeV       		lnN
+CMS_htt_QCDShape_etau_nobtag_8TeV               shape
 CMS_htt_ZJetFakeTau_etau_nobtag_8TeV		lnN
 CMS_htt_ZLeptonFakeTau_etau_8TeV   		lnN
 #CMS_htt_ZEEShape_etau_8TeV         		shape

--- a/setup/et/unc-mssm-8TeV-08.vals
+++ b/setup/et/unc-mssm-8TeV-08.vals
@@ -17,6 +17,7 @@ eleTau_nobtag		TT				CMS_htt_ttbarNorm_8TeV				1.10
 eleTau_nobtag		VV				CMS_htt_DiBosonNorm_8TeV			1.15
 eleTau_nobtag		W				CMS_htt_WNorm_etau_nobtag_8TeV 			1.10
 eleTau_nobtag         	QCD				CMS_htt_QCDSyst_etau_nobtag_8TeV		1.10
+eleTau_nobtag         	QCD				CMS_htt_QCDShape_etau_nobtag_8TeV		1.00
 eleTau_nobtag		ZJ				CMS_htt_ZJetFakeTau_etau_nobtag_8TeV      	1.20
 eleTau_nobtag		ZL				CMS_htt_ZLeptonFakeTau_etau_8TeV		1.20
 #eleTau_nobtag		ZL				CMS_htt_ZEEShape_etau_8TeV			1.00    

--- a/setup/et/unc-mssm-8TeV-09.conf
+++ b/setup/et/unc-mssm-8TeV-09.conf
@@ -14,6 +14,7 @@ CMS_htt_WNorm_etau_btag_8TeV  		lnN
 CMS_htt_DiBosonNorm_8TeV		lnN
 CMS_htt_extrap_ztt_etau_btag_8TeV	lnN
 CMS_htt_QCDSyst_etau_btag_8TeV    	lnN
+CMS_htt_QCDShape_etau_btag_8TeV    	shape
 CMS_htt_ZLeptonFakeTau_etau_8TeV   	lnN
 CMS_htt_ZJetFakeTau_etau_btag_8TeV   	lnN
 #CMS_htt_ZEEShape_etau_8TeV         	shape

--- a/setup/et/unc-mssm-8TeV-09.vals
+++ b/setup/et/unc-mssm-8TeV-09.vals
@@ -27,6 +27,7 @@ eleTau_btag	 	VV	          	CMS_htt_DiBosonNorm_8TeV 		1.15
 eleTau_btag		W	          	CMS_htt_WNorm_etau_btag_8TeV 		1.30
 eleTau_btag		ZTT	          	CMS_htt_extrap_ztt_etau_btag_8TeV	1.03
 eleTau_btag         	QCD	          	CMS_htt_QCDSyst_etau_btag_8TeV		1.20
+eleTau_btag         	QCD	          	CMS_htt_QCDShape_etau_btag_8TeV		1.00
 eleTau_btag         	ZL	          	CMS_htt_ZLeptonFakeTau_etau_8TeV	1.20
 eleTau_btag         	ZJ	          	CMS_htt_ZJetFakeTau_etau_btag_8TeV	1.20
 #eleTau_btag		ZL			CMS_htt_ZEEShape_etau_8TeV		1.00    

--- a/setup/mt/unc-mssm-7TeV-08.conf
+++ b/setup/mt/unc-mssm-7TeV-08.conf
@@ -12,5 +12,6 @@ CMS_htt_ttbarNorm_7TeV				lnN
 CMS_htt_WNorm_mutau_nobtag_7TeV			lnN
 CMS_htt_DiBosonNorm_7TeV			lnN
 CMS_htt_QCDSyst_mutau_nobtag_7TeV       	lnN
+CMS_htt_QCDShape_mutau_nobtag_7TeV              shape
 CMS_htt_ZJetFakeTau_mutau_nobtag_7TeV		lnN
 CMS_htt_ZLeptonFakeTau_mutau_7TeV	   	lnN

--- a/setup/mt/unc-mssm-7TeV-08.vals
+++ b/setup/mt/unc-mssm-7TeV-08.vals
@@ -14,6 +14,7 @@ muTau_nobtag			TT				CMS_htt_ttbarNorm_7TeV				1.08
 muTau_nobtag			W				CMS_htt_WNorm_mutau_nobtag_7TeV 		1.10
 muTau_nobtag			VV				CMS_htt_DiBosonNorm_7TeV			1.15
 muTau_nobtag                  	QCD				CMS_htt_QCDSyst_mutau_nobtag_7TeV		1.10
+muTau_nobtag                  	QCD				CMS_htt_QCDShape_mutau_nobtag_7TeV		1.00
 muTau_nobtag			ZJ				CMS_htt_ZJetFakeTau_mutau_nobtag_7TeV      	1.20
 muTau_nobtag			ZL				CMS_htt_ZLeptonFakeTau_mutau_7TeV		1.30
 

--- a/setup/mt/unc-mssm-7TeV-09.conf
+++ b/setup/mt/unc-mssm-7TeV-09.conf
@@ -16,4 +16,5 @@ CMS_htt_extrap_ztt_mutau_btag_7TeV	lnN
 CMS_htt_ZJetFakeTau_mutau_btag_7TeV 	lnN
 CMS_htt_ZLeptonFakeTau_mutau_7TeV	lnN
 CMS_htt_QCDSyst_mutau_btag_7TeV    	lnN
+CMS_htt_QCDShape_mutau_btag_7TeV        shape
 

--- a/setup/mt/unc-mssm-7TeV-09.vals
+++ b/setup/mt/unc-mssm-7TeV-09.vals
@@ -19,6 +19,7 @@ muTau_btag		TT     		  	CMS_htt_ttbar_emb_7TeV 			1.14
 muTau_btag	 	VV	          	CMS_htt_DiBosonNorm_7TeV 		1.15
 muTau_btag		W	          	CMS_htt_WNorm_mutau_btag_7TeV 		1.30
 muTau_btag          	QCD	          	CMS_htt_QCDSyst_mutau_btag_7TeV		1.20
+muTau_btag          	QCD	          	CMS_htt_QCDShape_mutau_btag_7TeV        1.00
 muTau_btag		ZJ			CMS_htt_ZJetFakeTau_mutau_btag_7TeV    	1.20
 muTau_btag		ZL			CMS_htt_ZLeptonFakeTau_mutau_7TeV	1.30
 

--- a/setup/mt/unc-mssm-8TeV-08.conf
+++ b/setup/mt/unc-mssm-8TeV-08.conf
@@ -12,5 +12,6 @@ CMS_htt_ttbarNorm_8TeV				lnN
 CMS_htt_DiBosonNorm_8TeV			lnN
 CMS_htt_WNorm_mutau_nobtag_8TeV			lnN
 CMS_htt_QCDSyst_mutau_nobtag_8TeV       	lnN
+CMS_htt_QCDShape_mutau_nobtag_8TeV              shape
 CMS_htt_ZJetFakeTau_mutau_nobtag_8TeV		lnN
 CMS_htt_ZLeptonFakeTau_mutau_8TeV	   	lnN

--- a/setup/mt/unc-mssm-8TeV-08.vals
+++ b/setup/mt/unc-mssm-8TeV-08.vals
@@ -18,6 +18,7 @@ muTau_nobtag			TT				CMS_htt_ttbarNorm_8TeV				1.10
 muTau_nobtag			W				CMS_htt_WNorm_mutau_nobtag_8TeV 		1.10
 muTau_nobtag			VV				CMS_htt_DiBosonNorm_8TeV			1.15 
 muTau_nobtag                  	QCD				CMS_htt_QCDSyst_mutau_nobtag_8TeV		1.10
+muTau_nobtag                  	QCD				CMS_htt_QCDShape_mutau_nobtag_8TeV		1.00
 muTau_nobtag			ZJ				CMS_htt_ZJetFakeTau_mutau_nobtag_8TeV      	1.20
 muTau_nobtag			ZL				CMS_htt_ZLeptonFakeTau_mutau_8TeV		1.30
 

--- a/setup/mt/unc-mssm-8TeV-09.conf
+++ b/setup/mt/unc-mssm-8TeV-09.conf
@@ -14,6 +14,6 @@ CMS_htt_DiBosonNorm_8TeV 		lnN
 CMS_htt_WNorm_mutau_btag_8TeV		lnN
 CMS_htt_extrap_ztt_mutau_btag_8TeV	lnN
 CMS_htt_QCDSyst_mutau_btag_8TeV    	lnN
+CMS_htt_QCDShape_mutau_btag_8TeV        shape
 CMS_htt_ZJetFakeTau_mutau_btag_8TeV 	lnN
 CMS_htt_ZLeptonFakeTau_mutau_8TeV	lnN
-

--- a/setup/mt/unc-mssm-8TeV-09.vals
+++ b/setup/mt/unc-mssm-8TeV-09.vals
@@ -26,6 +26,7 @@ muTau_btag		TT     		  	CMS_htt_ttbar_emb_8TeV 			1.14
 muTau_btag	 	VV	          	CMS_htt_DiBosonNorm_8TeV 		1.15
 muTau_btag		W	          	CMS_htt_WNorm_mutau_btag_8TeV 		1.30
 muTau_btag          	QCD	          	CMS_htt_QCDSyst_mutau_btag_8TeV		1.20
+muTau_btag          	QCD	          	CMS_htt_QCDShape_mutau_btag_8TeV        1.00
 muTau_btag		ZJ			CMS_htt_ZJetFakeTau_mutau_btag_8TeV    	1.20
 muTau_btag		ZL			CMS_htt_ZLeptonFakeTau_mutau_8TeV	1.30
 


### PR DESCRIPTION
This pull request just adding the QCD shape systematic for the MSSM datacards.  A separate pull request for a new ZL shape nuisance may follow - still waiting for confirmation from other analysts that this is ok to add.
These will both need to be added for the SM cards at some point too.
