### PR TITLE
added the .scan file for copying to the local workspace

### DIFF
--- a/scripts/lxb-limit.py
+++ b/scripts/lxb-limit.py
@@ -65,6 +65,7 @@ $CMSSW_BASE/src/HiggsAnalysis/HiggsToTauTau/scripts/limit.py {options} {tmphead}
 
 echo "Copy {tmphead}/{tail} --> {dirhead}{tail} (root output files only)"
 cp {tmphead}/{tail}/*.root {dirhead}{tail}
+cp {tmphead}/{tail}/.scan {dirhead}{tail}
 if [ -d {tmphead}/{tail}/out ] ;
   then
     mkdir -p {dirhead}/{tail}/out ;


### PR DESCRIPTION
Fixed a missing file for the likelihood-scan. The .scan file containing the information on the scan-range was not copied.
