### PR TITLE
Update style of post-fit plots

### DIFF
--- a/src/HttStyles.cc
+++ b/src/HttStyles.cc
@@ -196,7 +196,7 @@ void CMSPrelim(const char* dataset, const char* channel, double lowX, double low
   lumi->SetBorderSize(   0 );
   lumi->SetFillStyle(    0 );
   lumi->SetTextAlign(   12 );
-  lumi->SetTextSize ( 0.03 );
+  lumi->SetTextSize ( 0.04 );
   lumi->SetTextColor(    1 );
   lumi->SetTextFont (   62 );
   lumi->AddText(dataset);
@@ -206,7 +206,7 @@ void CMSPrelim(const char* dataset, const char* channel, double lowX, double low
   chan->SetBorderSize(   0 );
   chan->SetFillStyle(    0 );
   chan->SetTextAlign(   12 );
-  chan->SetTextSize ( 0.05 );
+  chan->SetTextSize ( 0.04 );
   chan->SetTextColor(    1 );
   chan->SetTextFont (   62 );
   chan->AddText(channel);

--- a/test/templates/HTT_EE_X_template.C
+++ b/test/templates/HTT_EE_X_template.C
@@ -136,19 +136,19 @@ HTT_EE_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
 
   // determine category tag
   const char* category = ""; const char* category_extra = ""; const char* category_extra2 = "";
-  if(std::string(directory) == std::string("ee_0jet_low"             )){ category = "ee";          }    
-  if(std::string(directory) == std::string("ee_0jet_low"             )){ category_extra = "0-jet low";          }    
-  if(std::string(directory) == std::string("ee_0jet_high"            )){ category = "ee";          }    
-  if(std::string(directory) == std::string("ee_0jet_high"            )){ category_extra = "0-jet high";         }    
-  if(std::string(directory) == std::string("ee_1jet_low"          )){ category = "ee";          }    
-  if(std::string(directory) == std::string("ee_1jet_low"          )){ category_extra = "1-jet low";       }    
-  if(std::string(directory) == std::string("ee_1jet_high"          )){ category = "ee";          }    
-  if(std::string(directory) == std::string("ee_1jet_high"          )){ category_extra = "1-jet high";       }    
-  if(std::string(directory) == std::string("ee_vbf"            )){ category = "ee";          }    
-  if(std::string(directory) == std::string("ee_vbf"            )){ category_extra = "VBF";              }    
-  if(std::string(directory) == std::string("ee_nobtag"               )){ category = "ee";          }    
-  if(std::string(directory) == std::string("ee_nobtag"               )){ category_extra = "No B-Tag";                        }    
-  if(std::string(directory) == std::string("ee_btag"                 )){ category = "ee";          }    
+  if(std::string(directory) == std::string("ee_0jet_low"             )){ category = "ee";          }
+  if(std::string(directory) == std::string("ee_0jet_low"             )){ category_extra = "0-jet low p_{T}(e)";          }
+  if(std::string(directory) == std::string("ee_0jet_high"            )){ category = "ee";          }
+  if(std::string(directory) == std::string("ee_0jet_high"            )){ category_extra = "0-jet high p_{T}(e)";         }
+  if(std::string(directory) == std::string("ee_1jet_low"          )){ category = "ee";          }
+  if(std::string(directory) == std::string("ee_1jet_low"          )){ category_extra = "1-jet low p_{T}(e)";       }
+  if(std::string(directory) == std::string("ee_1jet_high"          )){ category = "ee";          }
+  if(std::string(directory) == std::string("ee_1jet_high"          )){ category_extra = "1-jet high p_{T}(e)";       }
+  if(std::string(directory) == std::string("ee_vbf"            )){ category = "ee";          }
+  if(std::string(directory) == std::string("ee_vbf"            )){ category_extra = "2-jet";              }
+  if(std::string(directory) == std::string("ee_nobtag"               )){ category = "ee";          }
+  if(std::string(directory) == std::string("ee_nobtag"               )){ category_extra = "No B-Tag";                        }
+  if(std::string(directory) == std::string("ee_btag"                 )){ category = "ee";          }
   if(std::string(directory) == std::string("ee_btag"                 )){ category_extra = "B-Tag";                           }
 
   const char* dataset;
@@ -156,8 +156,8 @@ HTT_EE_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   if(std::string(inputfile).find("7TeV")!=std::string::npos){dataset = "CMS Preliminary,  H#rightarrow#tau#tau, 4.9 fb^{-1} at 7 TeV";}
   if(std::string(inputfile).find("8TeV")!=std::string::npos){dataset = "CMS Preliminary,  H#rightarrow#tau#tau, 19.7 fb^{-1} at 8 TeV";}
 #else
-  if(std::string(inputfile).find("7TeV")!=std::string::npos){dataset = "CMS,  H#rightarrow#tau#tau, 4.9 fb^{-1} at 7 TeV";}
-  if(std::string(inputfile).find("8TeV")!=std::string::npos){dataset = "CMS,  H#rightarrow#tau#tau, 19.7 fb^{-1} at 8 TeV";}
+  if(std::string(inputfile).find("7TeV")!=std::string::npos){dataset = "CMS, 4.9 fb^{-1} at 7 TeV";}
+  if(std::string(inputfile).find("8TeV")!=std::string::npos){dataset = "CMS, 19.7 fb^{-1} at 8 TeV";}
 #endif
 
   TFile* input = new TFile(inputfile.c_str());
@@ -396,7 +396,7 @@ HTT_EE_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   SetLegendStyle(leg);
   leg->AddEntry(ggH  , "#phi#rightarrow#tau#tau" , "L" );
 #else
-  TLegend* leg = new TLegend(0.50, 0.65, 0.95, 0.90);
+  TLegend* leg = new TLegend(0.55, 0.60, 0.94, 0.89);
   SetLegendStyle(leg);
 #ifndef DROP_SIGNAL
   if(SIGNAL_SCALE!=1){

--- a/test/templates/HTT_EM_X_template.C
+++ b/test/templates/HTT_EM_X_template.C
@@ -49,8 +49,8 @@ float maximum(TH1F* h, bool LOG=false){
     return 50*h->GetMaximum(); 
   }
   else{
-    if(h->GetMaximum()>  12){ return 10.*TMath::Nint((1.35*h->GetMaximum()/10.)); }
-    if(h->GetMaximum()> 1.2){ return TMath::Nint((1.65*h->GetMaximum())); }
+    if(h->GetMaximum()>  12){ return 10.*TMath::Nint((1.20*h->GetMaximum()/10.)); }
+    if(h->GetMaximum()> 1.2){ return TMath::Nint((1.50*h->GetMaximum())); }
     return 1.6*h->GetMaximum(); 
   }
 }
@@ -159,21 +159,23 @@ HTT_EM_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., TString 
 
   // determine category tag
   const char* category = ""; const char* category_extra = ""; const char* category_extra2 = "";
-  if(std::string(directory) == std::string("emu_0jet_low"             )){ category = "e#mu";          }    
-  if(std::string(directory) == std::string("emu_0jet_low"             )){ category_extra = "0-jet low";          }    
-  if(std::string(directory) == std::string("emu_0jet_high"            )){ category = "e#mu";          }    
-  if(std::string(directory) == std::string("emu_0jet_high"            )){ category_extra = "0-jet high";         }    
-  if(std::string(directory) == std::string("emu_1jet_low"          )){ category = "e#mu, ";          }    
-  if(std::string(directory) == std::string("emu_1jet_low"          )){ category_extra = "1-jet low";       }    
-  if(std::string(directory) == std::string("emu_1jet_high"          )){ category = "e#mu";          }    
-  if(std::string(directory) == std::string("emu_1jet_high"          )){ category_extra = "1-jet high";       }    
-  if(std::string(directory) == std::string("emu_vbf_loose"            )){ category = "e#mu";          }    
-  if(std::string(directory) == std::string("emu_vbf_loose"            )){ category_extra = "VBF loose";              }    
-  if(std::string(directory) == std::string("emu_vbf_tight"            )){ category = "e#mu";          }    
-  if(std::string(directory) == std::string("emu_vbf_tight"            )){ category_extra = "VBF tight";              }    
-  if(std::string(directory) == std::string("emu_nobtag"               )){ category = "e#mu";          }    
-  if(std::string(directory) == std::string("emu_nobtag"               )){ category_extra = "No B-Tag";                        }    
-  if(std::string(directory) == std::string("emu_btag"                 )){ category = "e#mu";          }    
+  if(std::string(directory) == std::string("emu_0jet_low"             )){ category = "e#mu";          }
+  if(std::string(directory) == std::string("emu_0jet_low"             )){ category_extra = "0-jet low p_{T}(#mu)";          }
+  if(std::string(directory) == std::string("emu_0jet_high"            )){ category = "e#mu";          }
+  if(std::string(directory) == std::string("emu_0jet_high"            )){ category_extra = "0-jet high p_{T}(#mu)";         }
+  if(std::string(directory) == std::string("emu_1jet_low"          )){ category = "e#mu";          }
+  if(std::string(directory) == std::string("emu_1jet_low"          )){ category_extra = "1-jet low p_{T}(#mu)";       }
+  if(std::string(directory) == std::string("emu_1jet_high"          )){ category = "e#mu";          }
+  if(std::string(directory) == std::string("emu_1jet_high"          )){ category_extra = "1-jet high p_{T}(#mu)";       }
+  if(std::string(directory) == std::string("emu_vbf_loose"            )){ category = "e#mu";          }
+  if(std::string(directory) == std::string("emu_vbf_loose"            )){ category_extra = "Loose VBF tag";              }
+  if(std::string(directory) == std::string("emu_vbf_loose") 
+        &&  std::string(inputfile).find("7TeV")!=std::string::npos    ){ category_extra = "VBF tag";              }
+  if(std::string(directory) == std::string("emu_vbf_tight"            )){ category = "e#mu";          }
+  if(std::string(directory) == std::string("emu_vbf_tight"            )){ category_extra = "Tight VBF tag";              }
+  if(std::string(directory) == std::string("emu_nobtag"               )){ category = "e#mu";          }
+  if(std::string(directory) == std::string("emu_nobtag"               )){ category_extra = "No B-Tag";                        }
+  if(std::string(directory) == std::string("emu_btag"                 )){ category = "e#mu";          }
   if(std::string(directory) == std::string("emu_btag"                 )){ category_extra = "B-Tag";                           }
 
   const char* dataset;
@@ -181,8 +183,8 @@ HTT_EM_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., TString 
   if(std::string(inputfile).find("7TeV")!=std::string::npos){dataset = "CMS Preliminary,  H#rightarrow#tau#tau, 4.9 fb^{-1} at 7 TeV";}
   if(std::string(inputfile).find("8TeV")!=std::string::npos){dataset = "CMS Preliminary,  H#rightarrow#tau#tau, 19.7 fb^{-1} at 8 TeV";}
 #else
-  if(std::string(inputfile).find("7TeV")!=std::string::npos){dataset = "CMS,  H#rightarrow#tau#tau, 4.9 fb^{-1} at 7 TeV";}
-  if(std::string(inputfile).find("8TeV")!=std::string::npos){dataset = "CMS,  H#rightarrow#tau#tau, 19.7 fb^{-1} at 8 TeV";}
+  if(std::string(inputfile).find("7TeV")!=std::string::npos){dataset = "CMS, 4.9 fb^{-1} at 7 TeV";}
+  if(std::string(inputfile).find("8TeV")!=std::string::npos){dataset = "CMS, 19.7 fb^{-1} at 8 TeV";}
 #endif
   
   TFile* input = new TFile(inputfile.c_str());
@@ -431,7 +433,7 @@ HTT_EM_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., TString 
 
   //CMSPrelim(dataset, "#tau_{e}#tau_{#mu}", 0.17, 0.835);
   CMSPrelim(dataset, "", 0.16, 0.835);
-  TPaveText* chan     = new TPaveText(0.20, (category_extra2 && category_extra2[0]=='\0') ? 0.65+0.061 : 0.65+0.061, 0.32, 0.75+0.161, "tlbrNDC");
+  TPaveText* chan     = new TPaveText(0.55, 0.35, 0.94, 0.55, "tlbrNDC");
   chan->SetBorderSize(   0 );
   chan->SetFillStyle(    0 );
   chan->SetTextAlign(   12 );
@@ -470,7 +472,7 @@ HTT_EM_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., TString 
   SetLegendStyle(leg);
   leg->AddEntry(ggH  , "#phi#rightarrow#tau#tau" , "L" );
 #else
-  TLegend* leg = new TLegend(0.50, 0.65, 0.95, 0.90);
+  TLegend* leg = new TLegend(0.55, 0.60, 0.94, 0.89);
   SetLegendStyle(leg);
 #ifndef DROP_SIGNAL
   if(SIGNAL_SCALE!=1){

--- a/test/templates/HTT_ET_X_template.C
+++ b/test/templates/HTT_ET_X_template.C
@@ -49,8 +49,8 @@ float maximum(TH1F* h, bool LOG=false){
     return 50*h->GetMaximum(); 
   }
   else{
-    if(h->GetMaximum()>  12){ return 10.*TMath::Nint((1.35*h->GetMaximum()/10.)); }
-    if(h->GetMaximum()> 1.2){ return TMath::Nint((1.65*h->GetMaximum())); }
+    if(h->GetMaximum()>  12){ return 10.*TMath::Nint((1.20*h->GetMaximum()/10.)); }
+    if(h->GetMaximum()> 1.2){ return TMath::Nint((1.50*h->GetMaximum())); }
     return 1.6*h->GetMaximum(); 
   }
 }
@@ -168,28 +168,28 @@ HTT_ET_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., TString 
 
   // determine category tag
   const char* category = ""; const char* category_extra = ""; const char* category_extra2 = "";
-  if(std::string(directory) == std::string("eleTau_0jet_low"             )){ category = "e#tau_{h}";          }    
-  if(std::string(directory) == std::string("eleTau_0jet_low"             )){ category_extra = "0-jet low";          }    
-  if(std::string(directory) == std::string("eleTau_0jet_medium"          )){ category = "e#tau_{h}";          }    
-  if(std::string(directory) == std::string("eleTau_0jet_medium"          )){ category_extra = "0-jet medium";       }    
-  if(std::string(directory) == std::string("eleTau_0jet_high"            )){ category = "e#tau_{h}";          }    
-  if(std::string(directory) == std::string("eleTau_0jet_high"            )){ category_extra = "0-jet high";         }    
-  if(std::string(directory) == std::string("eleTau_1jet_medium"          )){ category = "e#tau_{h}";          }    
-  if(std::string(directory) == std::string("eleTau_1jet_medium"          )){ category_extra = "1-jet medium";       }    
-  if(std::string(directory) == std::string("eleTau_1jet_high_lowhiggs"   )){ category = "e#tau_{h}";                          }    
-  if(std::string(directory) == std::string("eleTau_1jet_high_lowhiggs"   )){ category_extra= "1-jet high";  }
-  if(std::string(directory) == std::string("eleTau_1jet_high_mediumhiggs")){ category = "e#tau_{h}";                          }    
-  if(std::string(directory) == std::string("eleTau_1jet_high_mediumhiggs")){ category_extra= "1-jet high"; }
+  if(std::string(directory) == std::string("eleTau_0jet_low"             )){ category = "e#tau_{h}";          }
+  if(std::string(directory) == std::string("eleTau_0jet_low"             )){ category_extra = "0-jet low p_{T}(#tau_{h})";          }
+  if(std::string(directory) == std::string("eleTau_0jet_medium"          )){ category = "e#tau_{h}";          }
+  if(std::string(directory) == std::string("eleTau_0jet_medium"          )){ category_extra = "0-jet low p_{T}(#tau_{h})";       }
+  if(std::string(directory) == std::string("eleTau_0jet_high"            )){ category = "e#tau_{h}";          }
+  if(std::string(directory) == std::string("eleTau_0jet_high"            )){ category_extra = "0-jet high p_{T}(#tau_{h})";         }
+  if(std::string(directory) == std::string("eleTau_1jet_medium"          )){ category = "e#tau_{h}";          }
+  if(std::string(directory) == std::string("eleTau_1jet_medium"          )){ category_extra = "1-jet low p_{T}(#tau_{h})";       }
+  if(std::string(directory) == std::string("eleTau_1jet_high_lowhiggs"   )){ category = "e#tau_{h}";                          }
+  if(std::string(directory) == std::string("eleTau_1jet_high_lowhiggs"   )){ category_extra= "1-jet high p_{T}(#tau_{h})";  }
+  if(std::string(directory) == std::string("eleTau_1jet_high_mediumhiggs")){ category = "e#tau_{h}";                          }
+  if(std::string(directory) == std::string("eleTau_1jet_high_mediumhiggs")){ category_extra= "1-jet high p_{T}(#tau_{h})"; }
   if(std::string(directory) == std::string("eleTau_1jet_high_mediumhiggs")){ category_extra2= "boost"; }
-  if(std::string(directory) == std::string("eleTau_vbf"                  )){ category = "e#tau_{h}";          }    
-  if(std::string(directory) == std::string("eleTau_vbf"                  )){ category_extra = "VBF loose";              }    
-  if(std::string(directory) == std::string("eleTau_vbf_loose"            )){ category = "e#tau_{h}";          }    
-  if(std::string(directory) == std::string("eleTau_vbf_loose"            )){ category_extra = "VBF loose";              }    
-  if(std::string(directory) == std::string("eleTau_vbf_tight"            )){ category = "e#tau_{h}";          }    
-  if(std::string(directory) == std::string("eleTau_vbf_tight"            )){ category_extra = "VBF tight";              }    
-  if(std::string(directory) == std::string("eleTau_nobtag"               )){ category = "e#tau_{h}";          }    
-  if(std::string(directory) == std::string("eleTau_nobtag"               )){ category_extra = "No B-Tag";                        }    
-  if(std::string(directory) == std::string("eleTau_btag"                 )){ category = "e#tau_{h}";          }    
+  if(std::string(directory) == std::string("eleTau_vbf"                  )){ category = "e#tau_{h}";          }
+  if(std::string(directory) == std::string("eleTau_vbf"                  )){ category_extra = "VBF tag";              }
+  if(std::string(directory) == std::string("eleTau_vbf_loose"            )){ category = "e#tau_{h}";          }
+  if(std::string(directory) == std::string("eleTau_vbf_loose"            )){ category_extra = "Loose VBF tag";              }
+  if(std::string(directory) == std::string("eleTau_vbf_tight"            )){ category = "e#tau_{h}";          }
+  if(std::string(directory) == std::string("eleTau_vbf_tight"            )){ category_extra = "Tight VBF tag";              }
+  if(std::string(directory) == std::string("eleTau_nobtag"               )){ category = "e#tau_{h}";          }
+  if(std::string(directory) == std::string("eleTau_nobtag"               )){ category_extra = "No B-Tag";                        }
+  if(std::string(directory) == std::string("eleTau_btag"                 )){ category = "e#tau_{h}";          }
   if(std::string(directory) == std::string("eleTau_btag"                 )){ category_extra = "B-Tag";                           }
 
   const char* dataset;
@@ -197,8 +197,8 @@ HTT_ET_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., TString 
   if(std::string(inputfile).find("7TeV")!=std::string::npos){dataset = "CMS Preliminary,  H#rightarrow#tau#tau, 4.9 fb^{-1} at 7 TeV";}
   if(std::string(inputfile).find("8TeV")!=std::string::npos){dataset = "CMS Preliminary,  H#rightarrow#tau#tau, 19.7 fb^{-1} at 8 TeV";}
 #else
-  if(std::string(inputfile).find("7TeV")!=std::string::npos){dataset = "CMS,  H#rightarrow#tau#tau, 4.9 fb^{-1} at 7 TeV";}
-  if(std::string(inputfile).find("8TeV")!=std::string::npos){dataset = "CMS,  H#rightarrow#tau#tau, 19.7 fb^{-1} at 8 TeV";}
+  if(std::string(inputfile).find("7TeV")!=std::string::npos){dataset = "CMS, 4.9 fb^{-1} at 7 TeV";}
+  if(std::string(inputfile).find("8TeV")!=std::string::npos){dataset = "CMS, 19.7 fb^{-1} at 8 TeV";}
 #endif
   
   TFile* input = new TFile(inputfile.c_str());
@@ -438,7 +438,7 @@ HTT_ET_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., TString 
 
   //CMSPrelim(dataset, "#tau_{e}#tau_{h}", 0.17, 0.835);
   CMSPrelim(dataset, "", 0.16, 0.835);
-  TPaveText* chan     = new TPaveText(0.20, (category_extra2 && category_extra2[0]=='\0') ? 0.65+0.061 : 0.65+0.061, 0.32, 0.75+0.161, "tlbrNDC");
+  TPaveText* chan     = new TPaveText(0.55, 0.35, 0.94, 0.55, "tlbrNDC");
   chan->SetBorderSize(   0 );
   chan->SetFillStyle(    0 );
   chan->SetTextAlign(   12 );
@@ -487,7 +487,7 @@ HTT_ET_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., TString 
   SetLegendStyle(leg);
   leg->AddEntry(ggH  , "#phi#rightarrow#tau#tau" , "L" );
 #else
-  TLegend* leg = new TLegend(0.50, 0.65, 0.95, 0.90);
+  TLegend* leg = new TLegend(0.55, 0.60, 0.94, 0.89);
   SetLegendStyle(leg);
 #ifndef DROP_SIGNAL
   if(SIGNAL_SCALE!=1){

--- a/test/templates/HTT_MM_X_template.C
+++ b/test/templates/HTT_MM_X_template.C
@@ -54,8 +54,8 @@ float maximum(TH1F* h, bool LOG=false){
     return 50*h->GetMaximum(); 
   }
   else{
-    if(h->GetMaximum()>  12){ return 10.*TMath::Nint((1.35*h->GetMaximum()/10.)); }
-    if(h->GetMaximum()> 1.2){ return TMath::Nint((1.65*h->GetMaximum())); }
+    if(h->GetMaximum()>  12){ return 10.*TMath::Nint((1.20*h->GetMaximum()/10.)); }
+    if(h->GetMaximum()> 1.2){ return TMath::Nint((1.50*h->GetMaximum())); }
     return 1.6*h->GetMaximum(); 
   }
 }
@@ -136,19 +136,19 @@ HTT_MM_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
 
   // determine category tag
   const char* category = ""; const char* category_extra = ""; const char* category_extra2 = "";
-  if(std::string(directory) == std::string("mumu_0jet_low"             )){ category = "#mu#mu";          }    
-  if(std::string(directory) == std::string("mumu_0jet_low"             )){ category_extra = "0-jet low";          }    
-  if(std::string(directory) == std::string("mumu_0jet_high"            )){ category = "#mu#mu";          }    
-  if(std::string(directory) == std::string("mumu_0jet_high"            )){ category_extra = "0-jet high";         }    
-  if(std::string(directory) == std::string("mumu_1jet_low"          )){ category = "#mu#mu";          }    
-  if(std::string(directory) == std::string("mumu_1jet_low"          )){ category_extra = "1-jet low";       }    
-  if(std::string(directory) == std::string("mumu_1jet_high"          )){ category = "#mu#mu";          }    
-  if(std::string(directory) == std::string("mumu_1jet_high"          )){ category_extra = "1-jet high";       }    
-  if(std::string(directory) == std::string("mumu_vbf"            )){ category = "#mu#mu";          }    
-  if(std::string(directory) == std::string("mumu_vbf"            )){ category_extra = "VBF";              }    
-  if(std::string(directory) == std::string("mumu_nobtag"               )){ category = "#mu#mu";          }    
-  if(std::string(directory) == std::string("mumu_nobtag"               )){ category_extra = "No B-Tag";                        }    
-  if(std::string(directory) == std::string("mumu_btag"                 )){ category = "#mu#mu";          }    
+  if(std::string(directory) == std::string("mumu_0jet_low"             )){ category = "#mu#mu";          }
+  if(std::string(directory) == std::string("mumu_0jet_low"             )){ category_extra = "0-jet low p_{T}(#mu)";          }
+  if(std::string(directory) == std::string("mumu_0jet_high"            )){ category = "#mu#mu";          }
+  if(std::string(directory) == std::string("mumu_0jet_high"            )){ category_extra = "0-jet high p_{T}(#mu)";         }
+  if(std::string(directory) == std::string("mumu_1jet_low"          )){ category = "#mu#mu";          }
+  if(std::string(directory) == std::string("mumu_1jet_low"          )){ category_extra = "1-jet low p_{T}(#mu)";       }
+  if(std::string(directory) == std::string("mumu_1jet_high"          )){ category = "#mu#mu";          }
+  if(std::string(directory) == std::string("mumu_1jet_high"          )){ category_extra = "1-jet high p_{T}(#mu)";       }
+  if(std::string(directory) == std::string("mumu_vbf"            )){ category = "#mu#mu";          }
+  if(std::string(directory) == std::string("mumu_vbf"            )){ category_extra = "2-jet";              }
+  if(std::string(directory) == std::string("mumu_nobtag"               )){ category = "#mu#mu";          }
+  if(std::string(directory) == std::string("mumu_nobtag"               )){ category_extra = "No B-Tag";                        }
+  if(std::string(directory) == std::string("mumu_btag"                 )){ category = "#mu#mu";          }
   if(std::string(directory) == std::string("mumu_btag"                 )){ category_extra = "B-Tag";                           }
 
   const char* dataset;
@@ -156,8 +156,8 @@ HTT_MM_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   if(std::string(inputfile).find("7TeV")!=std::string::npos){dataset = "CMS Preliminary,  H#rightarrow#tau#tau, 4.9 fb^{-1} at 7 TeV";}
   if(std::string(inputfile).find("8TeV")!=std::string::npos){dataset = "CMS Preliminary,  H#rightarrow#tau#tau, 19.7 fb^{-1} at 8 TeV";}
 #else
-  if(std::string(inputfile).find("7TeV")!=std::string::npos){dataset = "CMS,  H#rightarrow#tau#tau, 4.9 fb^{-1} at 7 TeV";}
-  if(std::string(inputfile).find("8TeV")!=std::string::npos){dataset = "CMS,  H#rightarrow#tau#tau, 19.7 fb^{-1} at 8 TeV";}
+  if(std::string(inputfile).find("7TeV")!=std::string::npos){dataset = "CMS, 4.9 fb^{-1} at 7 TeV";}
+  if(std::string(inputfile).find("8TeV")!=std::string::npos){dataset = "CMS, 19.7 fb^{-1} at 8 TeV";}
 #endif
  
   TFile* input = new TFile(inputfile.c_str());
@@ -408,7 +408,7 @@ HTT_MM_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   SetLegendStyle(leg);
   leg->AddEntry(ggH  , "#phi#rightarrow#tau#tau" , "L" );
 #else
-  TLegend* leg = new TLegend(0.50, 0.65, 0.95, 0.90);
+  TLegend* leg = new TLegend(0.55, 0.60, 0.94, 0.89);
   SetLegendStyle(leg);
 #ifndef DROP_SIGNAL
   if(SIGNAL_SCALE!=1){

--- a/test/templates/HTT_MT_X_template.C
+++ b/test/templates/HTT_MT_X_template.C
@@ -49,8 +49,8 @@ float maximum(TH1F* h, bool LOG=false){
     return 50*h->GetMaximum(); 
   }
   else{
-    if(h->GetMaximum()>  12){ return 10.*TMath::Nint((1.35*h->GetMaximum()/10.)); }
-    if(h->GetMaximum()> 1.2){ return TMath::Nint((1.65*h->GetMaximum())); }
+    if(h->GetMaximum()>  12){ return 10.*TMath::Nint((1.20*h->GetMaximum()/10.)); }
+    if(h->GetMaximum()> 1.2){ return TMath::Nint((1.50*h->GetMaximum())); }
     return 1.6*h->GetMaximum(); 
   }
 }
@@ -166,26 +166,28 @@ HTT_MT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., TString 
 
   // determine category tag
   const char* category = ""; const char* category_extra = ""; const char* category_extra2 = "";
-  if(std::string(directory) == std::string("muTau_0jet_low"             )){ category = "#mu#tau_{h}";          }    
-  if(std::string(directory) == std::string("muTau_0jet_low"             )){ category_extra = "0-jet low";          }    
-  if(std::string(directory) == std::string("muTau_0jet_medium"          )){ category = "#mu#tau_{h}";          }    
-  if(std::string(directory) == std::string("muTau_0jet_medium"          )){ category_extra = "0-jet medium";       }    
-  if(std::string(directory) == std::string("muTau_0jet_high"            )){ category = "#mu#tau_{h}";          }    
-  if(std::string(directory) == std::string("muTau_0jet_high"            )){ category_extra = "0-jet high";         }    
-  if(std::string(directory) == std::string("muTau_1jet_medium"          )){ category = "#mu#tau_{h}";          }    
-  if(std::string(directory) == std::string("muTau_1jet_medium"          )){ category_extra = "1-jet medium";       }    
-  if(std::string(directory) == std::string("muTau_1jet_high_lowhiggs"   )){ category = "#mu#tau_{h}";                          }    
-  if(std::string(directory) == std::string("muTau_1jet_high_lowhiggs"   )){ category_extra= "1-jet high";  }
-  if(std::string(directory) == std::string("muTau_1jet_high_mediumhiggs")){ category = "#mu#tau_{h}";                          }    
-  if(std::string(directory) == std::string("muTau_1jet_high_mediumhiggs")){ category_extra= "1-jet high"; }
+  if(std::string(directory) == std::string("muTau_0jet_low"             )){ category = "#mu#tau_{h}";          }
+  if(std::string(directory) == std::string("muTau_0jet_low"             )){ category_extra = "0-jet low p_{T}(#tau_{h})";          }
+  if(std::string(directory) == std::string("muTau_0jet_medium"          )){ category = "#mu#tau_{h}";          }
+  if(std::string(directory) == std::string("muTau_0jet_medium"          )){ category_extra = "0-jet low p_{T}(#tau_{h})";       }
+  if(std::string(directory) == std::string("muTau_0jet_high"            )){ category = "#mu#tau_{h}";          }
+  if(std::string(directory) == std::string("muTau_0jet_high"            )){ category_extra = "0-jet high p_{T}(#tau_{h})";         }
+  if(std::string(directory) == std::string("muTau_1jet_medium"          )){ category = "#mu#tau_{h}";          }
+  if(std::string(directory) == std::string("muTau_1jet_medium"          )){ category_extra = "1-jet low p_{T}(#tau_{h})";       }
+  if(std::string(directory) == std::string("muTau_1jet_high_lowhiggs"   )){ category = "#mu#tau_{h}";                          }
+  if(std::string(directory) == std::string("muTau_1jet_high_lowhiggs"   )){ category_extra= "1-jet high p_{T}(#tau_{h})";  }
+  if(std::string(directory) == std::string("muTau_1jet_high_mediumhiggs")){ category = "#mu#tau_{h}";                          }
+  if(std::string(directory) == std::string("muTau_1jet_high_mediumhiggs")){ category_extra= "1-jet high p_{T}(#tau_{h})"; }
   if(std::string(directory) == std::string("muTau_1jet_high_mediumhiggs")){ category_extra2= "boost"; }
-  if(std::string(directory) == std::string("muTau_vbf_loose"            )){ category = "#mu#tau_{h}";          }    
-  if(std::string(directory) == std::string("muTau_vbf_loose"            )){ category_extra = "VBF loose";              }    
-  if(std::string(directory) == std::string("muTau_vbf_tight"            )){ category = "#mu#tau_{h}";          }    
-  if(std::string(directory) == std::string("muTau_vbf_tight"            )){ category_extra = "VBF tight";              }    
-  if(std::string(directory) == std::string("muTau_nobtag"               )){ category = "#mu#tau_{h}";          }    
-  if(std::string(directory) == std::string("muTau_nobtag"               )){ category_extra = "No B-Tag";                        }    
-  if(std::string(directory) == std::string("muTau_btag"                 )){ category = "#mu#tau_{h}";          }    
+  if(std::string(directory) == std::string("muTau_vbf"                  )){ category = "#mu#tau_{h}";          }
+  if(std::string(directory) == std::string("muTau_vbf"                  )){ category_extra = "VBF tag";              }
+  if(std::string(directory) == std::string("muTau_vbf_loose"            )){ category = "#mu#tau_{h}";          }
+  if(std::string(directory) == std::string("muTau_vbf_loose"            )){ category_extra = "Loose VBF tag";              }
+  if(std::string(directory) == std::string("muTau_vbf_tight"            )){ category = "#mu#tau_{h}";          }
+  if(std::string(directory) == std::string("muTau_vbf_tight"            )){ category_extra = "Tight VBF tag";              }
+  if(std::string(directory) == std::string("muTau_nobtag"               )){ category = "#mu#tau_{h}";          }
+  if(std::string(directory) == std::string("muTau_nobtag"               )){ category_extra = "No B-Tag";                        }
+  if(std::string(directory) == std::string("muTau_btag"                 )){ category = "#mu#tau_{h}";          }
   if(std::string(directory) == std::string("muTau_btag"                 )){ category_extra = "B-Tag";                           }
 
   const char* dataset;
@@ -193,8 +195,8 @@ HTT_MT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., TString 
   if(std::string(inputfile).find("7TeV")!=std::string::npos){dataset = "CMS Preliminary,  H#rightarrow#tau#tau, 4.9 fb^{-1} at 7 TeV";}
   if(std::string(inputfile).find("8TeV")!=std::string::npos){dataset = "CMS Preliminary,  H#rightarrow#tau#tau, 19.7 fb^{-1} at 8 TeV";}
 #else
-  if(std::string(inputfile).find("7TeV")!=std::string::npos){dataset = "CMS,  H#rightarrow#tau#tau, 4.9 fb^{-1} at 7 TeV";}
-  if(std::string(inputfile).find("8TeV")!=std::string::npos){dataset = "CMS,  H#rightarrow#tau#tau, 19.7 fb^{-1} at 8 TeV";}
+  if(std::string(inputfile).find("7TeV")!=std::string::npos){dataset = "CMS, 4.9 fb^{-1} at 7 TeV";}
+  if(std::string(inputfile).find("8TeV")!=std::string::npos){dataset = "CMS, 19.7 fb^{-1} at 8 TeV";}
 #endif
  
   // open example histogram file
@@ -452,7 +454,7 @@ HTT_MT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., TString 
 
   //CMSPrelim(dataset, "#tau_{#mu}#tau_{h}", 0.17, 0.835);
   CMSPrelim(dataset, "", 0.16, 0.835);
-  TPaveText* chan     = new TPaveText(0.20, (category_extra2 && category_extra2[0]=='\0') ? 0.65+0.061 : 0.65+0.061, 0.32, 0.75+0.161, "tlbrNDC");
+  TPaveText* chan     = new TPaveText(0.55, 0.35, 0.94, 0.55, "tlbrNDC");
   chan->SetBorderSize(   0 );
   chan->SetFillStyle(    0 );
   chan->SetTextAlign(   12 );
@@ -501,7 +503,7 @@ HTT_MT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., TString 
   SetLegendStyle(leg);
   leg->AddEntry(ggH  , "#phi#rightarrow#tau#tau" , "L" );
 #else
-  TLegend* leg = new TLegend(0.50, 0.65, 0.95, 0.90);
+  TLegend* leg = new TLegend(0.55, 0.60, 0.94, 0.89);
   SetLegendStyle(leg);
 #ifndef DROP_SIGNAL
   if(SIGNAL_SCALE!=1){

--- a/test/templates/HTT_TT_X_template.C
+++ b/test/templates/HTT_TT_X_template.C
@@ -47,8 +47,8 @@ float maximum(TH1F* h, bool LOG=false){
     return 50*h->GetMaximum(); 
   }
   else{
-    if(h->GetMaximum()>  12){ return 10.*TMath::Nint((1.35*h->GetMaximum()/10.)); }
-    if(h->GetMaximum()> 1.2){ return TMath::Nint((1.65*h->GetMaximum())); }
+    if(h->GetMaximum()>  12){ return 10.*TMath::Nint((1.20*h->GetMaximum()/10.)); }
+    if(h->GetMaximum()> 1.2){ return TMath::Nint((1.50*h->GetMaximum())); }
     return 1.6*h->GetMaximum(); 
   }
 }
@@ -168,18 +168,16 @@ HTT_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., TString 
 
   // determine category tag
   const char* category = ""; const char* category_extra = ""; const char* category_extra2 = "";
-  if(std::string(directory) == std::string("tauTau_1jet_high_mediumhiggs")){ category = "#tau_{h}#tau_{h}";                          }    
-  if(std::string(directory) == std::string("tauTau_1jet_high_mediumhiggs")){ category_extra= "1-jet"; }
-  if(std::string(directory) == std::string("tauTau_1jet_high_mediumhiggs")){ category_extra2= "medium boost"; }
-  if(std::string(directory) == std::string("tauTau_1jet_high_highhiggs"  )){ category = "#tau_{h}#tau_{h}";                          }    
-  if(std::string(directory) == std::string("tauTau_1jet_high_highhiggs"  )){ category_extra= "1-jet"; }
-  if(std::string(directory) == std::string("tauTau_1jet_high_highhiggs"  )){ category_extra2= "high boost"; }
-  if(std::string(directory) == std::string("tauTau_vbf"                  )){ category = "#tau_{h}#tau_{h}";                          }    
-  if(std::string(directory) == std::string("tauTau_vbf"                  )){ category_extra = "VBF";                     }
-  if(std::string(directory) == std::string("tauTau_nobtag"               )){ category = "#tau_{h}#tau_{h}";                        }
-  if(std::string(directory) == std::string("tauTau_nobtag"               )){ category_extra = "No B-Tag";                        }
-  if(std::string(directory) == std::string("tauTau_btag"                 )){ category = "#tau_{h}#tau_{h}";                           }
-  if(std::string(directory) == std::string("tauTau_btag"                 )){ category_extra = "B-Tag";                           }
+  if(std::string(directory) == std::string("tauTau_1jet_high_mediumhiggs")){ category = "#tau_{h}#tau_{h}";           }
+  if(std::string(directory) == std::string("tauTau_1jet_high_mediumhiggs")){ category_extra= "1-jet boost";           }
+  if(std::string(directory) == std::string("tauTau_1jet_high_highhiggs"  )){ category = "#tau_{h}#tau_{h}";           }
+  if(std::string(directory) == std::string("tauTau_1jet_high_highhiggs"  )){ category_extra= "1-jet large boost";     }
+  if(std::string(directory) == std::string("tauTau_vbf"                  )){ category = "#tau_{h}#tau_{h}";           }
+  if(std::string(directory) == std::string("tauTau_vbf"                  )){ category_extra = "VBF tag";              }
+  if(std::string(directory) == std::string("tauTau_nobtag"               )){ category = "#tau_{h}#tau_{h}";           }
+  if(std::string(directory) == std::string("tauTau_nobtag"               )){ category_extra = "No B-Tag";             }
+  if(std::string(directory) == std::string("tauTau_btag"                 )){ category = "#tau_{h}#tau_{h}";           }
+  if(std::string(directory) == std::string("tauTau_btag"                 )){ category_extra = "B-Tag";                }
 
   const char* dataset;
 #ifdef MSSM
@@ -193,7 +191,7 @@ HTT_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., TString 
     }
   }
 #else
-  if(std::string(inputfile).find("8TeV")!=std::string::npos){dataset = "CMS,  H#rightarrow#tau#tau, 19.8 fb^{-1} at 8 TeV";}
+  if(std::string(inputfile).find("8TeV")!=std::string::npos){dataset = "CMS, 19.7 fb^{-1} at 8 TeV";}
 #endif
   
   // open example histogram file
@@ -387,7 +385,7 @@ HTT_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., TString 
 
   //CMSPrelim(dataset, "#tau_{h}#tau_{h}", 0.17, 0.835);
   CMSPrelim(dataset, "", 0.16, 0.835);  
-  TPaveText* chan     = new TPaveText(0.20, (category_extra2 && category_extra2[0]=='\0') ? 0.65+0.061 : 0.65+0.061, 0.32, 0.75+0.161, "tlbrNDC");
+  TPaveText* chan     = new TPaveText(0.55, 0.35, 0.94, 0.55, "tlbrNDC");
   chan->SetBorderSize(   0 );
   chan->SetFillStyle(    0 );
   chan->SetTextAlign(   12 );
@@ -436,7 +434,7 @@ HTT_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., TString 
   SetLegendStyle(leg);
   leg->AddEntry(ggH  , "#phi#rightarrow#tau#tau" , "L" );
 #else
-  TLegend* leg = new TLegend(0.50, 0.65, 0.95, 0.88);
+  TLegend* leg = new TLegend(0.55, 0.60, 0.94, 0.89);
   SetLegendStyle(leg);
   if(SIGNAL_SCALE!=1){
     leg->AddEntry(ggH  , TString::Format("%.0f#timesH(125 GeV)#rightarrow#tau#tau", SIGNAL_SCALE) , "L" );


### PR DESCRIPTION
- remove H->tt text from top label
- increase size of CMSPrelim text from 0.03 to 0.04
- Move the channel and category text to below the legend on
  the right (apart from ee and mm)
- add new category names
- increase size of legend and change position slightly
