### PR TITLE
Fix for negativ entries after horizontal morphing

### DIFF
--- a/python/horizontal_morphing.py
+++ b/python/horizontal_morphing.py
@@ -49,6 +49,29 @@ class Morph:
             hist.SetBinContent(1, 10e-6)
         return hist
 
+    def no_negative(self,file, directory, sample, value):
+        """
+        set any negative entries of the histogram to zero.
+        """
+        name = sample
+        hist = self.load_hist(file, directory, name.format(MASS=value))
+        print file, directory, name.format(MASS=value)
+        for i in range(hist.GetNbinsX()):
+            if hist.GetBinContent(i+1) < 0:
+                print "Warning: setting negativ content of bin {BIN} to zero".format(BIN=str(i))
+                hist.SetBinContent(i+1,0)
+        file.Cd("/"+directory)
+        hist.Write(name.format(MASS=value),ROOT.TObject.kOverwrite)
+        for uncert in self.uncerts:
+            for suffix in ['Up','Down']:
+                name = sample+'_'+uncert+suffix
+                hist = self.load_hist(file, directory, name.format(MASS=value))
+                for i in range(hist.GetNbinsX()):
+                    if hist.GetBinContent(i+1) < 0:
+                        hist.SetBinContent(i+1,0)
+                file.Cd("/"+directory)
+                hist.Write(name.format(MASS=value),ROOT.TObject.kOverwrite)
+
     def norm_hist(self, hist_lower, hist_upper, lower, upper, value) :
         """
         Determine the normalization for the morphed histogram from the lower and
@@ -146,3 +169,4 @@ class Morph:
                                 self.morph_hist(file, dir, sample+'_'+uncert+'Down', mass_low, mass_high, value)
                         except AttributeError:
                             print "Warning: could not find shape systematic %s, skipping"  % uncert
+                    self.no_negative(file, dir, sample, value)

--- a/scripts/doSM.py
+++ b/scripts/doSM.py
@@ -198,11 +198,12 @@ if options.update_setup :
         os.system("mv {SETUP}/mt/htt_mt.inputs-sm-8TeV-bak.root {SETUP}/mt/htt_mt.inputs-sm-8TeV.root".format(SETUP=setup))
         os.system("rm {SETUP}/mt/htt_mt.inputs-sm-8TeV-soft.root".format(SETUP=setup))
     ## apply horizontal morphing for processes, which have not been simulated for 7TeV: ggH_hww145, qqH_hww145
-    for file in glob.glob("{SETUP}/em/htt_em.inputs-sm-7TeV*.root".format(SETUP=setup)) :
-        template_morphing = Morph(file, 'emu_0jet_low,emu_0jet_high,emu_1jet_low,emu_1jet_high,emu_vbf_loose', 'ggH_hww{MASS}', 'QCDscale_ggH1in,CMS_scale_e_7TeV', '140,150', 5, True,'', '') 
-        template_morphing.run()
-        template_morphing = Morph(file, 'emu_0jet_low,emu_0jet_high,emu_1jet_low,emu_1jet_high,emu_vbf_loose', 'qqH_hww{MASS}', 'CMS_scale_e_7TeV', '140,150', 5, True,'', '') 
-        template_morphing.run()
+    if any('hww-sig' in ana for ana in analyses):
+        for file in glob.glob("{SETUP}/em/htt_em.inputs-sm-7TeV*.root".format(SETUP=setup)) :
+            template_morphing = Morph(file, 'emu_0jet_low,emu_0jet_high,emu_1jet_low,emu_1jet_high,emu_vbf_loose', 'ggH_hww{MASS}', 'QCDscale_ggH1in,CMS_scale_e_7TeV', '140,150', 5, True,'', '') 
+            template_morphing.run()
+            template_morphing = Morph(file, 'emu_0jet_low,emu_0jet_high,emu_1jet_low,emu_1jet_high,emu_vbf_loose', 'qqH_hww{MASS}', 'CMS_scale_e_7TeV', '140,150', 5, True,'', '') 
+            template_morphing.run()
     ## scale to SM cross section (main processes and all channels but those listed in do_not_scales)
     for chn in config.channels :
         for file in glob.glob("{SETUP}/{CHN}/*-sm-*.root".format(SETUP=setup, CHN=chn)) :


### PR DESCRIPTION
In some cases horizontal morphing return histograms with negativ entries in some bins.
This commit adds a function to set these entries to zero.
