### PR TITLE
fix doSM.py

### DIFF
--- a/scripts/doSM.py
+++ b/scripts/doSM.py
@@ -200,9 +200,13 @@ if options.update_setup :
     ## apply horizontal morphing for processes, which have not been simulated for 7TeV: ggH_hww145, qqH_hww145
     if any('hww-sig' in ana for ana in analyses):
         for file in glob.glob("{SETUP}/em/htt_em.inputs-sm-7TeV*.root".format(SETUP=setup)) :
-            template_morphing = Morph(file, 'emu_0jet_low,emu_0jet_high,emu_1jet_low,emu_1jet_high,emu_vbf_loose', 'ggH_hww{MASS}', 'QCDscale_ggH1in,CMS_scale_e_7TeV', '140,150', 5, True,'', '') 
+            template_morphing = Morph(file, 'emu_0jet_low,emu_1jet_low,emu_vbf_loose', 'ggH_hww{MASS}', 'QCDscale_ggH1in,CMS_scale_e_7TeV', '140,150', 5, True,'', '') 
             template_morphing.run()
-            template_morphing = Morph(file, 'emu_0jet_low,emu_0jet_high,emu_1jet_low,emu_1jet_high,emu_vbf_loose', 'qqH_hww{MASS}', 'CMS_scale_e_7TeV', '140,150', 5, True,'', '') 
+            template_morphing = Morph(file, 'emu_0jet_high,emu_1jet_high', 'ggH_hww{MASS}', 'QCDscale_ggH1in,CMS_scale_e_highpt_7TeV', '140,150', 5, True,'', '') 
+            template_morphing.run()
+            template_morphing = Morph(file, 'emu_0jet_low,emu_1jet_low,emu_vbf_loose', 'qqH_hww{MASS}', 'CMS_scale_e_7TeV', '140,150', 5, True,'', '') 
+            template_morphing.run()
+            template_morphing = Morph(file, 'emu_0jet_high,emu_1jet_high', 'qqH_hww{MASS}', 'CMS_scale_e_highpt_7TeV', '140,150', 5, True,'', '') 
             template_morphing.run()
     ## scale to SM cross section (main processes and all channels but those listed in do_not_scales)
     for chn in config.channels :


### PR DESCRIPTION
Hi all,

There's a problem with doSM.py when setting up with bbb:hww-sig. It fails at the step of running the horizontal morphing for the missing H->WW signal samples in the e-mu channel. I realised that it was looking for the wrong scale_e systematic templates in some categories, which is fixed in this pull request.  It's started failing now because of the update to python/horizontal_morphing.py to fix the negative bin issue - the new function fails if the requested histogram doesn't exist.

cheers,
Andrew
