### PR TITLE
Fix to stop Asimov dataset from being randomised for seed -1

### DIFF
--- a/python/AsimovDatacard.py
+++ b/python/AsimovDatacard.py
@@ -148,7 +148,7 @@ class AsimovDatacard(DatacardAdaptor) :
                                 BKG = bkg_list,
                                 SIG = sig_list.replace('$MASS',self.mass),
                                 DIR = bin,
-                                SEED = catseeds[ind],
+                                SEED = catseeds[ind] if not int(self.seed) == -1 else -1,
                                 SCALE = self.signal_scale,
                                 IDX = '' if self.update_file else index,
                                 DATA_OBS = self.list2string(card, bin, ['data_obs']) 


### PR DESCRIPTION
Hi Rene, noticed this bug-the new random seeding introduces randomising even when we request the Asimov dataset. Do not merge it just yet, I am just checking for any more bugs in the generation of the Asimov for the mass scan.
