### PR TITLE
1D mass scan correction to script

### DIFF
--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -627,7 +627,7 @@ if options.optInject :
                 for mass in struct[1][dir] :
                     os.system("limit.py --max-likelihood --collect-injected-toys {DIR}/{MASS}".format(DIR=dir, MASS=mass))
             ## finally obtain the result on data 
-            lxb_submit(struct[0], struct[1], "--max-likelihood", "{USER}".format(USER=options.opt))
+            lxb_submit(struct[0], struct[1], "--max-likelihood --stable-new", "{USER}".format(USER=options.opt))
             ## obtain the expected results using an asimov dataset
             opts+=" --mass-scan"
             for path in paths:


### PR DESCRIPTION
It is important that the maximum likelihood fit for the 1D mass scan is run with the same combine options for the toys and the real data, to get consistent nll values. Previously the real data was being submitted without any of the  '--stable' options and so a lot of the data points were failing.
