### PR TITLE
Fixes for the Submission of injected limits

### DIFF
--- a/scripts/lxb-injected.py
+++ b/scripts/lxb-injected.py
@@ -77,7 +77,7 @@ for m in masses :
     os.system("cp {PWD}/{PATH}/{DIR}/%s/{{vhtt,htt}}_* {TMPDIR}/{USER}/{DIR}_{JOBID}/%s/"%(m,m))
 os.system("cp -r {PWD}/{PATH}/{DIR}/common {TMPDIR}/{USER}/{DIR}_{JOBID}/")
 for m in masses :
-    if m and {MSSM}:
+    if m and not {MSSM}:
         if {INJECTEDMH}:
             os.system("python {CMSSW_BASE}/src/HiggsAnalysis/HiggsToTauTau/scripts/blindData.py --seed {RND} --injected-mass %s --inject-signal --X-allow-no-signal {TMPDIR}/{USER}/{DIR}_{JOBID}/%s"%(m,m))
         else:
@@ -204,7 +204,7 @@ with open(submit_name, 'w') as submit_script:
                 submit_script.write("error = %s/%s\n" % (os.getcwd(), script_file_name.replace('.py', '.stderr')))
                 submit_script.write("queue\n")
             elif options.lxq :
-                submit_script.write('qsub -l distro=sld5 -v scram_arch -v cmssw_base %s/%s\n'
+                submit_script.write('qsub -l distro=sld5 -v scram_arch -v cmssw_base %s %s/%s\n'
                                     % (bsubargs, os.getcwd(), script_file_name.replace('.py', '.sh')))
             else:
                 os.system('touch /{PWD}/log/{LOG}'.format(


### PR DESCRIPTION
Fixed a few bugs and issues in the lxb-injected.py script.
- fixed issue introduced with the usage of MSSM. The check fort MSSM usage was evaluated wrongly.
- fixed a broken submission command for lxq. The submission arguments where not propagated to the actual submission.
