### PR TITLE
Change bash/zsh ini() call for lxq mode. Change the naming convention for the working directory of lxb-xsec2tanb

### DIFF
--- a/scripts/lxb-limit.py
+++ b/scripts/lxb-limit.py
@@ -87,7 +87,7 @@ linux_ver=`lsb_release -s -r`
 echo $linux_ver
 if [[ $linux_ver < 6.0 ]];
 then
-     ini cmssw_cvmfs
+     eval "`/afs/desy.de/common/etc/local/ini/ini.pl cmssw_cvmfs`"
      export SCRAM_ARCH=slc5_amd64_gcc472
 else
      source /cvmfs/cms.cern.ch/cmsset_default.sh

--- a/scripts/lxb-xsec2tanb.py
+++ b/scripts/lxb-xsec2tanb.py
@@ -61,7 +61,7 @@ linux_ver=`lsb_release -s -r`
 echo $linux_ver
 if [[ $linux_ver < 6.0 ]];
 then
-     ini cmssw_cvmfs
+     eval "`/afs/desy.de/common/etc/local/ini/ini.pl cmssw_cvmfs`"
      export SCRAM_ARCH=slc5_amd64_gcc472
 else
      source /cvmfs/cms.cern.ch/cmsset_default.sh
@@ -159,7 +159,9 @@ masses = directories(args)[1]
 for dir in dirs :
     ana = dir[:dir.rfind('/')]
     limit = dir[len(ana)+1:]
-    jobname = ana[ana.rfind('/')+1:]+'-'+limit+'-'+options.name
+    #jobname = ana[ana.rfind('/')+1:]+'-'+limit+'-'+options.name #old naming. this was problematic, as it would overwrite scripts relative to different limits
+    cmd_ext = '-xsec2tanb'
+    jobname = dir.replace('/', '-').replace('LIMITS','scripts')+cmd_ext
     ## create submission scripts
     submit(jobname, dir, masses)
     ## execute


### PR DESCRIPTION
...doesn't work in all the cases), to an explicit call to ini.pl. Change the namng convention for the working directory of the submission scripts for lxb-xsec2tanb, bringing in line with the other scripts, to avoid each shell script running on the computing node being overwritten when running in parallel on different limit directories.
