### PR TITLE
- fixed segmentation violation in tailfit macro

### DIFF
--- a/macros/addFitNuisance.C
+++ b/macros/addFitNuisance.C
@@ -1,28 +1,31 @@
 #include <iostream>
-#include "TROOT.h"
-#include "TFile.h"
-#include "TKey.h"
-#include "TF1.h"
-#include "TFitResult.h"
-#include "TFitResultPtr.h"
-#include "TH1F.h"
-#include "TMath.h"
-#include "TPaveText.h"
-#include "TCanvas.h"
-#include "TLegend.h"
-#include "RooBinning.h"                                                                                                                                                               
-#include "RooPlot.h"                                                                                                                                                               
-#include "RooRealVar.h"   
-#include "RooConstVar.h"  
-#include "RooDataHist.h"   
-#include "RooDataSet.h"    
-#include "RooHistPdf.h"     
-#include "RooGenericPdf.h"
-#include "RooGaussian.h"
-#include "RooFitResult.h"
-#include "TMatrixDSym.h"
-#include "TMatrixDSymEigen.h"
-#include "TGraphAsymmErrors.h"
+#include <TROOT.h>
+#include <TFile.h>
+#include <TKey.h>
+#include <TF1.h>
+#include <TFitResult.h>
+#include <TFitResultPtr.h>
+#include <TH1F.h>
+#include <TMath.h>
+#include <TPaveText.h>
+#include <TCanvas.h>
+#include <TLegend.h>
+#include <RooBinning.h>                                                                                                                                                               
+#include <RooPlot.h>                                                                                                                                                               
+#include <RooRealVar.h>   
+#include <RooConstVar.h>  
+#include <RooDataHist.h>   
+#include <RooDataSet.h>    
+#include <RooHistPdf.h>     
+#include <RooGenericPdf.h>
+#include <RooGaussian.h>
+#include <RooFitResult.h>
+#include <RooCmdArg.h>
+#include <TMatrixDSym.h>
+#include <TMatrixDSymEigen.h>
+#include <TGraphAsymmErrors.h>
+
+using namespace RooFit;
 
 //Clone the file excluding the histogram (code stolen from Rene Brun)
 void copyDir(TDirectory *source,std::string iSkipHist,bool iFirst=true) { 
@@ -406,8 +409,8 @@ int addNuisance(const std::string& iFileName,
   RooFitResult  *lRFit = 0;
   double lFirst = iFirst;
   double lLast  = iLast;
-  //lRFit = lFit->chi2FitTo(*pH0,RooFit::Save(kTRUE),RooFit::Range(lFirst,lLast));
-  lRFit = lFit->fitTo(*pH0,RooFit::Save(kTRUE),RooFit::Range(lFirst,lLast),RooFit::Strategy(0)); 
+  //lRFit = lFit->chi2FitTo(*pH0,Save(kTRUE),Range(lFirst,lLast));
+  lRFit = lFit->fitTo(*pH0,Save(kTRUE),Range(lFirst,lLast),Strategy(0)); 
   
   //std::cout << lRFit->status() << " " <<  lRFit->covQual() << std::endl;
   if(!(lRFit->status()==0 && lRFit->covQual()==3))
@@ -946,7 +949,7 @@ void refitShift(const std::string& fitFunction_formula, double par0, double dpar
   RooConstVar constraint_mean("constraint_mean", "constraint_mean", 0.);
   RooConstVar constraint_width("constraint_width", "constraint_width", 3.);
   RooGaussian constraint_gaussian("constraint_gaussian", "constraint_gaussian", alpha, constraint_mean, constraint_width);
-  RooFitResult* tempFitResult = tempFitFunction->fitTo(fitData, RooFit::Save(true), RooFit::SumW2Error(true), RooFit::Strategy(0), RooFit::Minos(true), RooFit::ExternalConstraints(constraint_gaussian));
+  RooFitResult* tempFitResult = tempFitFunction->fitTo(fitData, Save(kTRUE), SumW2Error(kTRUE), Strategy(0), ExternalConstraints(constraint_gaussian));
   std::cout << "alpha = " << alpha.getVal() << std::endl;
   par0_refitted = par0 + alpha.getVal()*dpar0;
   par1_refitted = par1 + alpha.getVal()*dpar1;
@@ -1027,11 +1030,11 @@ int addNuisance2(const std::string& inputFileName,
     return 1;
   }
 
-  //if ( !verbosity ) {
-  //  RooMsgService::instance().setStreamStatus(0, false);
-  //  RooMsgService::instance().setStreamStatus(1, false);
-  //  RooMsgService::instance().setSilentMode(true);
-  //}
+  if ( !verbosity ) {
+    RooMsgService::instance().setStreamStatus(0, false);
+    RooMsgService::instance().setStreamStatus(1, false);
+    RooMsgService::instance().setSilentMode(true);
+  }
 
   // Load histogram that is to be fitted
   TFile* inputFile = new TFile(inputFileName.c_str());
@@ -1144,7 +1147,7 @@ int addNuisance2(const std::string& inputFileName,
   RooRealVar par0("par0", "par0", 1.e+2, 0., 1.e+3);
   RooRealVar par1("par1", "par1", 1., -1.e+4, 1.e+4);
   RooGenericPdf* fitFunction = new RooGenericPdf("genPdf", fitFunction_formula.data(), RooArgList(x, par0, par1));
-  RooFitResult* fitResult = fitFunction->fitTo(fitData, RooFit::Save(true), RooFit::SumW2Error(true), RooFit::Strategy(0), RooFit::Minos(true)); 
+  RooFitResult* fitResult = fitFunction->fitTo(fitData, Save(kTRUE), SumW2Error(kTRUE), Strategy(0)); 
   std::cout << "fit has finished:" << std::endl;
   std::cout << " status = " << fitResult->status() << ", qual(cov) " <<  fitResult->covQual() << ":" << std::endl;
   std::cout << " par0 = " << par0.getVal() << ", par1 = " << par1.getVal() << std::endl;

--- a/scripts/doMSSM_taupt.py
+++ b/scripts/doMSSM_taupt.py
@@ -485,7 +485,48 @@ if options.update_setup :
                     runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_fine_binning' -k '11' --range 250 --rangelast 1000 --fitoption 1 --fitmodel 1 --erroroption 1".format(
                         DIR=dir, ANA=ana))
                     runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_fine_binning' -k '12' --range 250 --rangelast 700 --fitoption 1 --fitmodel 1 --erroroption 1".format(
-                        DIR=dir, ANA=ana))                        
+                        DIR=dir, ANA=ana))
+                    ## tail fit for QCD shape uncertainties
+                    runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_CMS_htt_QCDfrNorm_tautau_8TeVUp_fine_binning' -k '13' --range 300 --rangelast 700 --fitoption 1 --fitmodel 1 --erroroption 1".format(
+                        DIR=dir, ANA=ana))
+                    runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_CMS_htt_QCDfrNorm_tautau_8TeVDown_fine_binning' -k '13' --range 300 --rangelast 700 --fitoption 1 --fitmodel 1 --erroroption 1".format(
+                        DIR=dir, ANA=ana))
+                    runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_CMS_htt_QCDfrShape_tautau_8TeVUp_fine_binning' -k '13' --range 300 --rangelast 700 --fitoption 1 --fitmodel 1 --erroroption 1".format(
+                        DIR=dir, ANA=ana))
+                    runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_CMS_htt_QCDfrShape_tautau_8TeVDown_fine_binning' -k '13' --range 300 --rangelast 700 --fitoption 1 --fitmodel 1 --erroroption 1".format(
+                        DIR=dir, ANA=ana))
+                    runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_CMS_htt_QCDfrNorm_tautau_8TeVUp_fine_binning' -k '14' --range 250 --rangelast 800 --fitoption 1 --fitmodel 1 --erroroption 1".format(
+                        DIR=dir, ANA=ana))
+                    runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_CMS_htt_QCDfrNorm_tautau_8TeVDown_fine_binning' -k '14' --range 250 --rangelast 800 --fitoption 1 --fitmodel 1 --erroroption 1".format(
+                        DIR=dir, ANA=ana))
+                    runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_CMS_htt_QCDfrShape_tautau_8TeVUp_fine_binning' -k '14' --range 250 --rangelast 800 --fitoption 1 --fitmodel 1 --erroroption 1".format(
+                        DIR=dir, ANA=ana))
+                    runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_CMS_htt_QCDfrShape_tautau_8TeVDown_fine_binning' -k '14' --range 250 --rangelast 800 --fitoption 1 --fitmodel 1 --erroroption 1".format(
+                        DIR=dir, ANA=ana))
+                    runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_CMS_htt_QCDfrNorm_tautau_8TeVUp_fine_binning' -k '10' --range 300 --rangelast 1000 --fitoption 1 --fitmodel 1 --erroroption 1".format(
+                        DIR=dir, ANA=ana))
+                    runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_CMS_htt_QCDfrNorm_tautau_8TeVDown_fine_binning' -k '10' --range 300 --rangelast 1000 --fitoption 1 --fitmodel 1 --erroroption 1".format(
+                        DIR=dir, ANA=ana))
+                    runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_CMS_htt_QCDfrShape_tautau_8TeVUp_fine_binning' -k '10' --range 300 --rangelast 1000 --fitoption 1 --fitmodel 1 --erroroption 1".format(
+                        DIR=dir, ANA=ana))
+                    runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_CMS_htt_QCDfrShape_tautau_8TeVDown_fine_binning' -k '10' --range 300 --rangelast 1000 --fitoption 1 --fitmodel 1 --erroroption 1".format(
+                        DIR=dir, ANA=ana))
+                    runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_CMS_htt_QCDfrNorm_tautau_8TeVUp_fine_binning' -k '11' --range 250 --rangelast 1000 --fitoption 1 --fitmodel 1 --erroroption 1".format(
+                        DIR=dir, ANA=ana))
+                    runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_CMS_htt_QCDfrNorm_tautau_8TeVDown_fine_binning' -k '11' --range 250 --rangelast 1000 --fitoption 1 --fitmodel 1 --erroroption 1".format(
+                        DIR=dir, ANA=ana))
+                    runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_CMS_htt_QCDfrShape_tautau_8TeVUp_fine_binning' -k '11' --range 250 --rangelast 1000 --fitoption 1 --fitmodel 1 --erroroption 1".format(
+                        DIR=dir, ANA=ana))
+                    runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_CMS_htt_QCDfrShape_tautau_8TeVDown_fine_binning' -k '11' --range 250 --rangelast 1000 --fitoption 1 --fitmodel 1 --erroroption 1".format(
+                        DIR=dir, ANA=ana))
+                    runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_CMS_htt_QCDfrNorm_tautau_8TeVUp_fine_binning' -k '12' --range 250 --rangelast 700 --fitoption 1 --fitmodel 1 --erroroption 1".format(
+                        DIR=dir, ANA=ana))
+                    runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_CMS_htt_QCDfrNorm_tautau_8TeVDown_fine_binning' -k '12' --range 250 --rangelast 700 --fitoption 1 --fitmodel 1 --erroroption 1".format(
+                        DIR=dir, ANA=ana))
+                    runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_CMS_htt_QCDfrShape_tautau_8TeVUp_fine_binning' -k '12' --range 250 --rangelast 700 --fitoption 1 --fitmodel 1 --erroroption 1".format(
+                        DIR=dir, ANA=ana))
+                    runCommand("addFitNuisance.py -s {DIR}/{ANA} -i htt_tt.inputs-mssm-8TeV-0.root -c tt -e 8TeV -b 'QCD_CMS_htt_QCDfrShape_tautau_8TeVDown_fine_binning' -k '12' --range 250 --rangelast 700 --fitoption 1 --fitmodel 1 --erroroption 1".format(
+                        DIR=dir, ANA=ana))
                 ## cleanup
                 runCommand("rm rootlogon.C")
                 runCommand("mkdir -p tail-fitting")

--- a/setup/et/unc-mssm-8TeV-10.vals
+++ b/setup/et/unc-mssm-8TeV-10.vals
@@ -33,4 +33,4 @@ eleTau_nobtag_low           	qqH_SM125                       QCDscale_qqH       
 eleTau_nobtag_low           	VH_SM125                        QCDscale_VH                                     1.01
 eleTau_nobtag_low           	qqH_SM125,VH_SM125              UEPS                                            1.05
 eleTau_nobtag_low           	ggH_SM125                       UEPS                                            1.013
-eleTau_nobtag_low		signal                       	CMS_htt_higgsPtReweight_8TeV			1.00
+eleTau_nobtag_low		ggH                       	CMS_htt_higgsPtReweight_8TeV			1.00

--- a/setup/et/unc-mssm-8TeV-11.vals
+++ b/setup/et/unc-mssm-8TeV-11.vals
@@ -33,4 +33,4 @@ eleTau_nobtag_medium           		qqH_SM125                       QCDscale_qqH   
 eleTau_nobtag_medium           		VH_SM125                        QCDscale_VH                                     	1.01
 eleTau_nobtag_medium           		qqH_SM125,VH_SM125              UEPS                                            	1.05
 eleTau_nobtag_medium           		ggH_SM125                       UEPS                                            	1.013
-eleTau_nobtag_medium			signal                       	CMS_htt_higgsPtReweight_8TeV				1.00
+eleTau_nobtag_medium			ggH                       	CMS_htt_higgsPtReweight_8TeV				1.00

--- a/setup/et/unc-mssm-8TeV-12.vals
+++ b/setup/et/unc-mssm-8TeV-12.vals
@@ -33,4 +33,4 @@ eleTau_nobtag_high           	qqH_SM125                       QCDscale_qqH      
 eleTau_nobtag_high           	VH_SM125                        QCDscale_VH                                     1.01
 eleTau_nobtag_high           	qqH_SM125,VH_SM125              UEPS                                            1.05
 eleTau_nobtag_high           	ggH_SM125                       UEPS                                            1.013
-eleTau_nobtag_high		signal                       	CMS_htt_higgsPtReweight_8TeV			1.00
+eleTau_nobtag_high		ggH                       	CMS_htt_higgsPtReweight_8TeV			1.00

--- a/setup/et/unc-mssm-8TeV-13.vals
+++ b/setup/et/unc-mssm-8TeV-13.vals
@@ -43,4 +43,4 @@ eleTau_btag_low      		qqH_SM125               	QCDscale_qqH                    
 eleTau_btag_low      		VH_SM125                	QCDscale_VH                             	1.04
 eleTau_btag_low      		qqH_SM125,VH_SM125      	UEPS                                    	1.007
 eleTau_btag_low      		ggH_SM125               	UEPS                                    	0.946
-eleTau_btag_low			signal                       	CMS_htt_higgsPtReweight_8TeV			1.00
+eleTau_btag_low			ggH                       	CMS_htt_higgsPtReweight_8TeV			1.00

--- a/setup/et/unc-mssm-8TeV-14.vals
+++ b/setup/et/unc-mssm-8TeV-14.vals
@@ -43,4 +43,4 @@ eleTau_btag_high      		qqH_SM125               	QCDscale_qqH                   
 eleTau_btag_high      		VH_SM125                	QCDscale_VH                             	1.04
 eleTau_btag_high      		qqH_SM125,VH_SM125      	UEPS                                    	1.007
 eleTau_btag_high      		ggH_SM125               	UEPS                                    	0.946
-eleTau_btag_high		signal                       	CMS_htt_higgsPtReweight_8TeV			1.00
+eleTau_btag_high		ggH                       	CMS_htt_higgsPtReweight_8TeV			1.00

--- a/setup/mt/unc-mssm-8TeV-10.vals
+++ b/setup/mt/unc-mssm-8TeV-10.vals
@@ -34,5 +34,5 @@ muTau_nobtag_low                    	qqH_SM125                       QCDscale_qq
 muTau_nobtag_low                    	VH_SM125                        QCDscale_VH                                     	1.01
 muTau_nobtag_low                    	qqH_SM125,VH_SM125              UEPS                                            	1.05
 muTau_nobtag_low                    	ggH_SM125                       UEPS                                            	1.013
-muTau_nobtag_low			signal                       	CMS_htt_higgsPtReweight_8TeV				1.00
+muTau_nobtag_low			ggH                       	CMS_htt_higgsPtReweight_8TeV				1.00
 

--- a/setup/mt/unc-mssm-8TeV-11.vals
+++ b/setup/mt/unc-mssm-8TeV-11.vals
@@ -34,5 +34,5 @@ muTau_nobtag_medium                  	qqH_SM125                       QCDscale_q
 muTau_nobtag_medium                  	VH_SM125                        QCDscale_VH                                     	1.01
 muTau_nobtag_medium                  	qqH_SM125,VH_SM125              UEPS                                            	1.05
 muTau_nobtag_medium                  	ggH_SM125                       UEPS                                            	1.013
-muTau_nobtag_medium			signal                       	CMS_htt_higgsPtReweight_8TeV				1.00
+muTau_nobtag_medium			ggH                       	CMS_htt_higgsPtReweight_8TeV				1.00
 

--- a/setup/mt/unc-mssm-8TeV-12.vals
+++ b/setup/mt/unc-mssm-8TeV-12.vals
@@ -34,5 +34,5 @@ muTau_nobtag_high                    	qqH_SM125                       QCDscale_q
 muTau_nobtag_high                    	VH_SM125                        QCDscale_VH                                     	1.01
 muTau_nobtag_high                    	qqH_SM125,VH_SM125              UEPS                                            	1.05
 muTau_nobtag_high                    	ggH_SM125                       UEPS                                            	1.013
-muTau_nobtag_high			signal                       	CMS_htt_higgsPtReweight_8TeV				1.00
+muTau_nobtag_high			ggH                       	CMS_htt_higgsPtReweight_8TeV				1.00
 

--- a/setup/mt/unc-mssm-8TeV-13.vals
+++ b/setup/mt/unc-mssm-8TeV-13.vals
@@ -42,4 +42,4 @@ muTau_btag_low              	qqH_SM125               	QCDscale_qqH              
 muTau_btag_low              	VH_SM125                	QCDscale_VH                             	1.04
 muTau_btag_low              	qqH_SM125,VH_SM125      	UEPS                                    	1.007
 muTau_btag_low              	ggH_SM125               	UEPS                                    	0.946
-muTau_btag_low			signal                       	CMS_htt_higgsPtReweight_8TeV			1.00
+muTau_btag_low			ggH                       	CMS_htt_higgsPtReweight_8TeV			1.00

--- a/setup/mt/unc-mssm-8TeV-14.vals
+++ b/setup/mt/unc-mssm-8TeV-14.vals
@@ -42,4 +42,4 @@ muTau_btag_high              	qqH_SM125               	QCDscale_qqH             
 muTau_btag_high              	VH_SM125                	QCDscale_VH                             	1.04
 muTau_btag_high              	qqH_SM125,VH_SM125      	UEPS                                    	1.007
 muTau_btag_high              	ggH_SM125               	UEPS                                    	0.946
-muTau_btag_high			signal                       	CMS_htt_higgsPtReweight_8TeV			1.00
+muTau_btag_high			ggH                       	CMS_htt_higgsPtReweight_8TeV			1.00

--- a/setup/tt/unc-mssm-8TeV-10.vals
+++ b/setup/tt/unc-mssm-8TeV-10.vals
@@ -30,4 +30,4 @@ tauTau_nobtag_low            	qqH_SM125                       QCDscale_qqH      
 tauTau_nobtag_low            	VH_SM125                        QCDscale_VH                                     	1.04            
 tauTau_nobtag_low            	qqH_SM125,VH_SM125              UEPS                                            	1.025
 tauTau_nobtag_low            	ggH_SM125                       UEPS                                            	0.975
-tauTau_nobtag_low            	signal                       	CMS_htt_higgsPtReweight_8TeV				1.00
+tauTau_nobtag_low            	ggH                       	CMS_htt_higgsPtReweight_8TeV				1.00

--- a/setup/tt/unc-mssm-8TeV-11.vals
+++ b/setup/tt/unc-mssm-8TeV-11.vals
@@ -30,4 +30,4 @@ tauTau_nobtag_medium         	qqH_SM125                       QCDscale_qqH      
 tauTau_nobtag_medium         	VH_SM125                        QCDscale_VH                                     	1.04            
 tauTau_nobtag_medium         	qqH_SM125,VH_SM125              UEPS                                            	1.025
 tauTau_nobtag_medium         	ggH_SM125                       UEPS                                            	0.975
-tauTau_nobtag_medium         	signal                       	CMS_htt_higgsPtReweight_8TeV				1.00
+tauTau_nobtag_medium         	ggH                       	CMS_htt_higgsPtReweight_8TeV				1.00

--- a/setup/tt/unc-mssm-8TeV-12.vals
+++ b/setup/tt/unc-mssm-8TeV-12.vals
@@ -30,4 +30,4 @@ tauTau_nobtag_high           	qqH_SM125                       QCDscale_qqH      
 tauTau_nobtag_high           	VH_SM125                        QCDscale_VH                                     	1.04            
 tauTau_nobtag_high           	qqH_SM125,VH_SM125              UEPS                                            	1.025
 tauTau_nobtag_high           	ggH_SM125                       UEPS                                            	0.975
-tauTau_nobtag_high           	signal                       	CMS_htt_higgsPtReweight_8TeV				1.00
+tauTau_nobtag_high           	ggH                       	CMS_htt_higgsPtReweight_8TeV				1.00

--- a/setup/tt/unc-mssm-8TeV-13.vals
+++ b/setup/tt/unc-mssm-8TeV-13.vals
@@ -30,4 +30,4 @@ tauTau_btag_low              	qqH_SM125                       QCDscale_qqH      
 tauTau_btag_low              	VH_SM125                        QCDscale_VH                                     	1.04            
 tauTau_btag_low              	qqH_SM125,VH_SM125              UEPS                                            	1.025
 tauTau_btag_low              	ggH_SM125                       UEPS                                            	0.975
-tauTau_btag_low              	signal                       	CMS_htt_higgsPtReweight_8TeV				1.00
+tauTau_btag_low              	ggH                       	CMS_htt_higgsPtReweight_8TeV				1.00

--- a/setup/tt/unc-mssm-8TeV-14.vals
+++ b/setup/tt/unc-mssm-8TeV-14.vals
@@ -30,5 +30,5 @@ tauTau_btag_high             	qqH_SM125                       QCDscale_qqH      
 tauTau_btag_high             	VH_SM125                        QCDscale_VH                                     	1.04            
 tauTau_btag_high             	qqH_SM125,VH_SM125              UEPS                                            	1.025
 tauTau_btag_high             	ggH_SM125                       UEPS                                            	0.975
-tauTau_btag_high             	signal                       	CMS_htt_higgsPtReweight_8TeV				1.00
+tauTau_btag_high             	ggH                       	CMS_htt_higgsPtReweight_8TeV				1.00
 


### PR DESCRIPTION
 (the fix is to not to qualify the fit options using the "RooFit::" namespace, i.e. use "using namespace RooFit;"+"Save" instead of "RooFit::Save"... still very weird)
- use tailfit also for QCD templates for jet -> tau fake-rate uncertainty
- apply Higgs Pt reweighting only to "ggH", not to "signal" (= bbH + ggH, i.e. don't apply Higgs Pt reweighting to b-associated production)
