### PR TITLE
 reduced yield uncertainty on QCD from 35% to 10%

### DIFF
--- a/setup/tt/unc-mssm-8TeV-10.vals
+++ b/setup/tt/unc-mssm-8TeV-10.vals
@@ -8,7 +8,7 @@ tauTau_nobtag_low         	TT				CMS_scale_j_8TeV					1.01
 tauTau_nobtag_low         	VV				CMS_scale_j_8TeV					1.03
 tauTau_nobtag_low		signal,SM,ZJ,ZL,TT,VV 		CMS_eff_b_8TeV 						0.98
 tauTau_nobtag_low		signal,SM,ZJ,ZL,TT,VV 		CMS_fake_b_8TeV 					0.98
-tauTau_nobtag_low         	QCD				CMS_htt_QCDSyst_tautau_nobtag_low_8TeV			1.35              
+tauTau_nobtag_low         	QCD				CMS_htt_QCDSyst_tautau_nobtag_low_8TeV			1.10              
 tauTau_nobtag_low         	QCD				CMS_htt_QCDfrNorm_tautau_8TeV        			1.00 
 tauTau_nobtag_low         	QCD				CMS_htt_QCDfrShape_tautau_8TeV        			1.00 
 tauTau_nobtag_low		W				CMS_htt_WNorm_tautau_nobtag_low_8TeV			1.30                  

--- a/setup/tt/unc-mssm-8TeV-11.vals
+++ b/setup/tt/unc-mssm-8TeV-11.vals
@@ -8,7 +8,7 @@ tauTau_nobtag_medium         	TT				CMS_scale_j_8TeV					1.01
 tauTau_nobtag_medium         	VV				CMS_scale_j_8TeV					1.03
 tauTau_nobtag_medium		signal,SM,ZJ,ZL,TT,VV 		CMS_eff_b_8TeV 						0.98
 tauTau_nobtag_medium		signal,SM,ZJ,ZL,TT,VV 		CMS_fake_b_8TeV 					0.98
-tauTau_nobtag_medium         	QCD				CMS_htt_QCDSyst_tautau_nobtag_medium_8TeV		1.35              
+tauTau_nobtag_medium         	QCD				CMS_htt_QCDSyst_tautau_nobtag_medium_8TeV		1.10              
 tauTau_nobtag_medium         	QCD				CMS_htt_QCDfrNorm_tautau_8TeV        			1.00 
 tauTau_nobtag_medium         	QCD				CMS_htt_QCDfrShape_tautau_8TeV        			1.00 
 tauTau_nobtag_medium		W				CMS_htt_WNorm_tautau_nobtag_medium_8TeV			1.30                  

--- a/setup/tt/unc-mssm-8TeV-12.vals
+++ b/setup/tt/unc-mssm-8TeV-12.vals
@@ -8,7 +8,7 @@ tauTau_nobtag_high         	TT				CMS_scale_j_8TeV					1.01
 tauTau_nobtag_high         	VV				CMS_scale_j_8TeV					1.03
 tauTau_nobtag_high		signal,SM,ZJ,ZL,TT,VV 		CMS_eff_b_8TeV 						0.98
 tauTau_nobtag_high		signal,SM,ZJ,ZL,TT,VV 		CMS_fake_b_8TeV 					0.98
-tauTau_nobtag_high         	QCD				CMS_htt_QCDSyst_tautau_nobtag_high_8TeV			1.35              
+tauTau_nobtag_high         	QCD				CMS_htt_QCDSyst_tautau_nobtag_high_8TeV			1.10             
 tauTau_nobtag_high         	QCD				CMS_htt_QCDfrNorm_tautau_8TeV        			1.00 
 tauTau_nobtag_high         	QCD				CMS_htt_QCDfrShape_tautau_8TeV        			1.00 
 tauTau_nobtag_high		W				CMS_htt_WNorm_tautau_nobtag_high_8TeV			1.30                  

--- a/setup/tt/unc-mssm-8TeV-13.vals
+++ b/setup/tt/unc-mssm-8TeV-13.vals
@@ -8,7 +8,7 @@ tauTau_btag_low         	TT				CMS_scale_j_8TeV					1.01
 tauTau_btag_low         	VV				CMS_scale_j_8TeV					1.03
 tauTau_btag_low			signal,SM,TT,VV,ZLL        	CMS_eff_b_8TeV                  			1.09
 tauTau_btag_low			signal,SM,TT,VV,ZLL        	CMS_fake_b_8TeV                 			1.02
-tauTau_btag_low         	QCD				CMS_htt_QCDSyst_tautau_btag_low_8TeV			1.35              
+tauTau_btag_low         	QCD				CMS_htt_QCDSyst_tautau_btag_low_8TeV			1.10              
 tauTau_btag_low         	QCD				CMS_htt_QCDfrNorm_tautau_8TeV        			1.00 
 tauTau_btag_low         	QCD				CMS_htt_QCDfrShape_tautau_8TeV        			1.00 
 tauTau_btag_low			W				CMS_htt_WNorm_tautau_btag_low_8TeV			1.30                  

--- a/setup/tt/unc-mssm-8TeV-14.vals
+++ b/setup/tt/unc-mssm-8TeV-14.vals
@@ -8,7 +8,7 @@ tauTau_btag_high         	TT				CMS_scale_j_8TeV					1.01
 tauTau_btag_high         	VV				CMS_scale_j_8TeV					1.03
 tauTau_btag_high		signal,SM,TT,VV,ZLL        	CMS_eff_b_8TeV                  			1.09
 tauTau_btag_high		signal,SM,TT,VV,ZLL        	CMS_fake_b_8TeV                 			1.02
-tauTau_btag_high         	QCD				CMS_htt_QCDSyst_tautau_btag_high_8TeV			1.35              
+tauTau_btag_high         	QCD				CMS_htt_QCDSyst_tautau_btag_high_8TeV			1.10             
 tauTau_btag_high         	QCD				CMS_htt_QCDfrNorm_tautau_8TeV        			1.00 
 tauTau_btag_high         	QCD				CMS_htt_QCDfrShape_tautau_8TeV        			1.00 
 tauTau_btag_high		W				CMS_htt_WNorm_tautau_btag_high_8TeV			1.30                  


### PR DESCRIPTION
 reduced yield uncertainty on QCD from 35% to 10%

(= OS/SS uncertainty used in etaua nd mutau channels; we now propagate the fake-rate uncertainties, so less additional uncertainty on yield is justified)
