### PR TITLE
Enabling bbb uncertainty merging for Hhh

### DIFF
--- a/data/Hhh-protocol.txt
+++ b/data/Hhh-protocol.txt
@@ -3,7 +3,8 @@
 #From src directory of CMSSW release, with the CombinedLimits and HiggsTauTau packages added as described on the twiki:
 # https://twiki.cern.ch/twiki/bin/viewauth/CMS/SWGuideHiggs2TauLimits
 #Use of doHTohh.py script to replace the individual scripts
-python HiggsAnalysis/HiggsToTauTau/scripts/doHTohh.py --update-all --config=HiggsAnalysis/HiggsToTauTau/data/limits.config-Hhh -a plain --label="SomeLabel" [--profile]
+#Note the syntax for bbb processes in the config file;  only the samples before the first comma are merged atm
+python HiggsAnalysis/HiggsToTauTau/scripts/doHTohh.py --update-all --config=HiggsAnalysis/HiggsToTauTau/data/limits.config-Hhh -a bbb --label="SomeLabel" [--profile] [--new-merging --new-merging-threshold 0.5]
 
 #The following command applies the correct XS*BR for each tanb point we are interested in for the model-dependent limits 
 lxb-xsec2tanb.py --ana-type="Hhh" --model="mhmodp" --customTanb="1,1.5,2,2.5,3" LIMITS-HTohh-mhmodp/*/*

--- a/data/limits.config-Hhh
+++ b/data/limits.config-Hhh
@@ -241,10 +241,10 @@ tt_names_8TeV = 2jet0tag 2jet1tag 2jet2tag
 
 [bbb-Hhh]
 
-em_threshold = 0.05
-et_threshold = 0.05
-mt_threshold = 0.05
-tt_threshold = 0.05
+em_threshold = 0.1
+et_threshold = 0.1
+mt_threshold = 0.1
+tt_threshold = 0.1
 
 em_categories_8TeV = 00,01,02,03,04
 et_categories_8TeV = 00,01,02
@@ -252,9 +252,9 @@ mt_categories_8TeV = 00,01,02
 tt_categories_8TeV = 00,01,02
 
 em_processes = Fakes,EWK,ttbar,Ztt
-et_processes = TT,QCD,ZTT,W,ZL,ZJ,VV
-mt_processes = TT,QCD,ZTT,W,ZL,ZJ,VV
-tt_processes = ZTT,TT,QCD,W,ZL,ZJ,VV
+et_processes = QCD>W>ZL>ZJ>VV,ZTT,TT
+mt_processes = QCD>W>ZL>ZJ>VV,ZTT,TT
+tt_processes = QCD>W>ZL>ZJ>VV,ZTT,TT
 
 
 

--- a/scripts/doHTohh.py
+++ b/scripts/doHTohh.py
@@ -221,13 +221,14 @@ if options.update_setup :
                         if options.new_merging :
                             filename='htt_'+chn+'.inputs-Hhh-'+per+'.root'
                             for cat in config.bbbcat[chn][per][idx].split(',') :
+                                print cat
                                 ## loop all categories in question for index idx
-                                if len(config.bbbproc[chn][idx].replace('>',',').split(','))>1 :
+                                if len(config.bbbproc[chn][idx].replace('>','+').split('+'))>1 :
                                     ## only get into action if there is more than one sample to do the merging for
                                     os.system("merge_bin_errors.py --folder {DIR} --processes {PROC} --bbb_threshold={BBBTHR} --merge_threshold={THRESH} --verbose {SOURCE} {TARGET}".format(
                                         ## this list has only one entry by construction
-                                        DIR=get_channel_dirs(chn, cat,per)[0],
-                                        PROC=config.bbbproc[chn][idx].replace('>',','),
+                                        DIR=get_channel_dirs("Hhh",chn, cat,per)[0],
+                                        PROC=config.bbbproc[chn][idx].split(',')[0].replace('>',','),
                                         BBBTHR=config.bbbthreshold[chn],
                                         THRESH=options.new_merging_threshold,
                                         SOURCE=dir+'/'+ana+'/'+chn+'/'+filename,
@@ -243,7 +244,7 @@ if options.update_setup :
                             PER=per,
                             NORMALIZE=normalize_bbb,
                             CAT=config.bbbcat[chn][per][idx],
-                            PROC=config.bbbproc[chn][idx].replace('>',',') if options.new_merging else config.bbbproc[chn][idx],
+                            PROC=config.bbbproc[chn][idx].replace('>',','),
                             THR=config.bbbthreshold[chn]
                             ))                   
                         os.system("rm -rf {DIR}/{ANA}".format(DIR=dir, ANA=ana))


### PR DESCRIPTION
Changes to make merging of bin-by-bin uncertainties for Hhh possible (allowing user to select which of the background uncertainties should be merged)
