### PR TITLE
Postfit plotting & layout/config file fixes

### DIFF
--- a/data/Hhh-protocol.txt
+++ b/data/Hhh-protocol.txt
@@ -27,9 +27,11 @@ submit.py --asymptotic --no-prefit [--physics-model="Hhh"] LIMITS-HTohh-ggHTohh/
 limit.py --max-likelihood LIMITS-HTohh/bbb/cmb/300
 
 #postfit plots
+#The --mA option in produce_macros_Hhh.py is only used as printout on the
+#postfit plots. You have to make sure mA corresponds to chosen mH and tanb
 cd HiggsAnalysis/HiggsToTauTau/test
-python mlfit_and_copy.py -a Hhh --mA 300 --tanb 2 [--profile] $CMSSW_BASE/src/LIMITS-label/bbb/cmb/300
-python produce_macros_Hhh.py -a Hhh --mA 300 --tanb 2 [--profile]  --config ../data/limits.config-Hhh
+python mlfit_and_copy.py -a Hhh --mH 300 --tanb 2 [--profile] $CMSSW_BASE/src/LIMITS-label/bbb/cmb/300
+python produce_macros_Hhh.py -a Hhh --mH 300 --tanb 2 --mA 285 [--profile]  --config ../data/limits.config-Hhh
 ./fixmacros.sh
 python run_macros.py -a Hhh --config ../data/limits.config-Hhh
 

--- a/data/Hhh-protocol.txt
+++ b/data/Hhh-protocol.txt
@@ -27,11 +27,9 @@ submit.py --asymptotic --no-prefit [--physics-model="Hhh"] LIMITS-HTohh-ggHTohh/
 limit.py --max-likelihood LIMITS-HTohh/bbb/cmb/300
 
 #postfit plots
-#The --mA option in produce_macros_Hhh.py is only used as printout on the
-#postfit plots. You have to make sure mA corresponds to chosen mH and tanb
 cd HiggsAnalysis/HiggsToTauTau/test
 python mlfit_and_copy.py -a Hhh --mH 300 --tanb 2 [--profile] $CMSSW_BASE/src/LIMITS-label/bbb/cmb/300
-python produce_macros_Hhh.py -a Hhh --mH 300 --tanb 2 --mA 285 [--profile]  --config ../data/limits.config-Hhh
+python produce_macros_Hhh.py -a Hhh --mH 300 --tanb 2 [--profile]  --config ../data/limits.config-Hhh
 ./fixmacros.sh
 python run_macros.py -a Hhh --config ../data/limits.config-Hhh
 

--- a/data/limits.config-Hhh
+++ b/data/limits.config-Hhh
@@ -228,14 +228,14 @@ periods = 8TeV
 channels = et mt tt
 
 em_categories_8TeV = 0 1 2 3 4
-et_categories_8TeV = 0 1 2
-mt_categories_8TeV = 0 1 2
+et_categories_8TeV = 1 2
+mt_categories_8TeV = 1 2
 tt_categories_8TeV = 0 1 2 
 
 
 em_names_8TeV = 2jet0tag 2jet1tag 2jet2tag 1jet0tag 1jet1tag
-et_names_8TeV = 2jet0tag 2jet1tag 2jet2tag
-mt_names_8TeV = 2jet0tag 2jet1tag 2jet2tag 
+et_names_8TeV = 2jet1tag 2jet2tag
+mt_names_8TeV = 2jet1tag 2jet2tag 
 tt_names_8TeV = 2jet0tag 2jet1tag 2jet2tag 
 
 
@@ -247,8 +247,8 @@ mt_threshold = 0.1
 tt_threshold = 0.1
 
 em_categories_8TeV = 00,01,02,03,04
-et_categories_8TeV = 00,01,02
-mt_categories_8TeV = 00,01,02
+et_categories_8TeV = 01,02
+mt_categories_8TeV = 01,02
 tt_categories_8TeV = 00,01,02
 
 em_processes = Fakes,EWK,ttbar,Ztt

--- a/macros/compareDeltaLimitHhh.C
+++ b/macros/compareDeltaLimitHhh.C
@@ -1,0 +1,531 @@
+#include "string" 
+#include "vector" 
+#include "fstream"
+#include "iomanip"
+#include "iostream"
+#include "algorithm"
+
+#include "TTree.h"
+#include "TFile.h"
+#include "TAxis.h"
+#include "TGraph.h"
+#include "TString.h"
+#include "TCanvas.h"
+#include "TLegend.h"
+#include "TPaveLabel.h"
+#include "TGraphAsymmErrors.h"
+
+#include "HiggsAnalysis/HiggsToTauTau/macros/Utils.h"
+#include "HiggsAnalysis/HiggsToTauTau/interface/HttStyles.h"
+#include "HiggsAnalysis/HiggsToTauTau/src/HttStyles.cc"
+
+static const double MARKER_SIZE = 1.3;  // 0.7
+
+bool
+channel(std::string& label){
+  return (label==std::string("cmb")        ||
+	  label==std::string("cmb-mvis")   ||
+	  label==std::string("cmb-ichep")  ||
+	  label==std::string("cmb+")       ||
+	  label==std::string("htt")        ||
+	  label==std::string("htt+")       ||
+	  label==std::string("vhtt")       ||
+	  label==std::string("whtt")       ||
+	  label==std::string("zhtt")       ||
+	  label==std::string("whhh")       ||
+	  label==std::string("incl")       ||
+	  label==std::string("0jet")       ||
+	  label==std::string("0jet-mvis")  ||
+	  label==std::string("0jet-ichep") ||
+	  label==std::string("2jet")       ||
+	  label==std::string("boost")      ||
+	  label==std::string("boost+0jet") ||
+	  label==std::string("boost-mvis") ||
+	  label==std::string("boost-ichep")||
+	  label==std::string("btag")       ||
+	  label==std::string("nobtag")     ||
+	  label==std::string("vbf")        ||
+	  label==std::string("vbf_0jet")   ||
+	  label==std::string("vbf-mvis")   ||
+	  label==std::string("vbf-ichep")  ||
+	  label==std::string("hgg")        ||	  
+	  label==std::string("hww")        ||
+	  label==std::string("hbb")        ||	  
+	  label==std::string("hmm")        ||
+	  label==std::string("tt")         ||
+	  label==std::string("tt-mvis")    ||
+	  label==std::string("tt-ichep")   ||
+	  label==std::string("em")         ||
+	  label==std::string("em-mvis")    ||
+	  label==std::string("em-ichep")   ||
+	  label==std::string("et")         ||
+	  label==std::string("et-mvis")    ||
+	  label==std::string("et-ichep")   ||
+	  label==std::string("mt")         ||
+	  label==std::string("mt-mvis")    ||
+	  label==std::string("mt-ichep")   ||
+	  label==std::string("mm")         ||
+	  label==std::string("mm-mvis")    ||
+	  label==std::string("mm-ichep")   ||
+	  label==std::string("ltt") 	   ||
+	  label==std::string("llt") 	   ||
+	  label==std::string("4l") 	   ||
+	  label==std::string("hzz4l")      ||
+	  label==std::string("hzz2l2q")    ||
+	  label==std::string("hzz2l2q")    ||
+	  label==std::string("hzz2l2t")    ||
+	  label==std::string("hzz2l2n")    ||
+	  label==std::string("ggH")        ||
+	  label==std::string("bbH")        ||
+	  label==std::string("mvis")       ||
+	  label==std::string("ichep")      ||
+	  label==std::string("test-0")     ||
+	  label==std::string("test-1")     ||
+	  label==std::string("test-2")     ||
+	  label==std::string("test-3")     ||
+	  label==std::string("test-4")     ||
+	  label==std::string("test-5")     ||
+	  label==std::string("old")        ||
+	  label==std::string("cmb-5fb")    ||
+	  label==std::string("hpa-5fb")    ||
+	  label==std::string("hpa-10fb")   ||
+	  label==std::string("saeff")      ||
+	  label==std::string("gluph")      ||
+	  label==std::string("nomix-200")  ||
+	  label==std::string("nomix+200")  ||
+	  label==std::string("mhmax-400")  ||
+	  label==std::string("mhmax-200")  ||
+	  label==std::string("mhmax+200")  ||
+	  label==std::string("mhmax+400")  ||
+	  label==std::string("mhmax+600")  ||
+	  label==std::string("mhmax+800")  ||
+	  label==std::string("MSSM-7TeV")  ||
+	  label==std::string("MSSM-8TeV")  ||
+	  label==std::string("HIG-11-020") ||
+	  label==std::string("HIG-11-029") ||
+	  label==std::string("HIG-12-018") ||
+	  label==std::string("HIG-12-032") ||
+	  label==std::string("HIG-12-043") ||
+	  label==std::string("HIG-12-050") ||
+	  label==std::string("mm-thomas"   ) ||
+	  label==std::string("em-MIT") ||
+	  label==std::string("em-IMPERIAL"   ) ||
+	  label==std::string("tt-CERN" ) ||
+	  label==std::string("tt-MIT"     ) ||
+	  label==std::string("et-WISCONSIN"     ) ||
+	  label==std::string("et-jose"     ) ||
+	  label==std::string("et-IMPERIAL"   ) ||
+	  label==std::string("mt-WISCONSIN"     ) || 
+	  label==std::string("mt-jose"     ) || 
+	  label==std::string("mt-IMPERIAL"   ) || 
+	  label==std::string("mt-matthew"  ) ||
+	  label==std::string("mt-aruna"    ) ||
+	  label==std::string("et-vbf-josh"     ) ||
+	  label==std::string("et-vbf-jose"     ) ||
+	  label==std::string("et-vbf-andrew"   ) ||
+	  label==std::string("mt-vbf-josh"     ) || 
+	  label==std::string("mt-vbf-jose"     ) || 
+	  label==std::string("mt-vbf-andrew"   ) ||
+	  label==std::string("et-boost-josh"     ) ||
+	  label==std::string("et-boost-jose"     ) ||
+	  label==std::string("et-boost-andrew"   ) ||
+	  label==std::string("mt-boost-josh"     ) || 
+	  label==std::string("mt-boost-jose"     ) || 
+	  label==std::string("mt-boost-andrew"   ) 
+	  );
+}
+
+std::string legendEntry(const std::string& channel){
+  std::string title;
+  if(channel==std::string("emu"       )) title = std::string("e#mu");
+  if(channel==std::string("em"        )) title = std::string("e#mu");
+  if(channel==std::string("em-mvis"   )) title = std::string("e#mu (with m_{vis})");
+  if(channel==std::string("em-ichep"  )) title = std::string("e#mu (HCP on ICHEP dataset)");
+  if(channel==std::string("etau"      )) title = std::string("e#tau_{h}");
+  if(channel==std::string("et"        )) title = std::string("e#tau_{h}");
+  if(channel==std::string("et-mvis"   )) title = std::string("e#tau_{h} (with m_{vis})");
+  if(channel==std::string("et-ichep"  )) title = std::string("e#tau_{h} (HCP in ICHEP dataset)");
+  if(channel==std::string("mutau"     )) title = std::string("#mu#tau_{h}");
+  if(channel==std::string("mt"        )) title = std::string("#mu#tau_{h}");
+  if(channel==std::string("mt-mvis"   )) title = std::string("#mu#tau_{h} (with m_{vis})");
+  if(channel==std::string("mt-ichep"  )) title = std::string("#mu#tau_{h} (HCP on ICHEP dataset)");
+  if(channel==std::string("tautau"    )) title = std::string("#tau_{h}#tau_{h}");
+  if(channel==std::string("tt"        )) title = std::string("#tau_{h}#tau_{h}");
+  if(channel==std::string("tt-mvis"   )) title = std::string("#tau_{h}#tau_{h} (with m_{vis})");
+  if(channel==std::string("tt-ichep"  )) title = std::string("#tau_{h}#tau_{h} (HCP on ICHEP dataset)");
+  if(channel==std::string("mumu"      )) title = std::string("#mu#mu");
+  if(channel==std::string("mm"        )) title = std::string("#mu#mu");
+  if(channel==std::string("mm-mvis"   )) title = std::string("#mu#mu (with m_{vis})");
+  if(channel==std::string("mm-ichep"  )) title = std::string("#mu#mu (HCP on ICHEP dataset)");
+  if(channel==std::string("vhtt"      )) title = std::string("VH#rightarrow#tau#tau+l(l)");
+  if(channel==std::string("whtt"      )) title = std::string("WH#rightarrow#tau_{l}#tau_{l}+l");
+  if(channel==std::string("zhtt"      )) title = std::string("ZH#rightarrow#tau_{l}#tau_{l}+ll");
+  if(channel==std::string("whhh"      )) title = std::string("WH#rightarrow#tau_{h}#tau_{h}+#mu");
+  if(channel==std::string("htt"       )) title = std::string("e#mu+e#tau_{h}+#mu#tau_{h}+#mu#mu");
+  if(channel==std::string("htt+"      )) title = std::string("e#mu+e#tau_{h}+#mu#tau_{h}+#mu#mu+#tau_{h}#tau_{h}");
+  if(channel==std::string("cmb"       )) title = std::string("Combined");
+  if(channel==std::string("cmb-mvis"  )) title = std::string("Combined (with m_{vis})");
+  if(channel==std::string("cmb-ichep" )) title = std::string("Combined (HCP on ICHEP dataset)");
+  if(channel==std::string("cmb+"      )) title = std::string("H#rightarrow#tau#tau + VH#rightarrow#tau#tau+l");
+  if(channel==std::string("incl"      )) title = std::string("Inclusive");
+  if(channel==std::string("0jet"      )) title = std::string("0-Jet");
+  if(channel==std::string("0jet-mvis" )) title = std::string("0-Jet (with m_{vis})");
+  if(channel==std::string("0jet-ichep")) title = std::string("0-Jet (HCP on ICHEP dataset)");
+  if(channel==std::string("2jet"      )) title = std::string("V(jj)H(#tau#tau)");
+  if(channel==std::string("vbf"       )) title = std::string("2-Jet (VBF) ICHEP analysis");
+  if(channel==std::string("vbf+0jet"  )) title = std::string("2-Jet (VBF)");
+  if(channel==std::string("vbf-mvis"  )) title = std::string("2-Jet (VBF) (with m_{vis})");
+  if(channel==std::string("vbf-ichep" )) title = std::string("2-Jet (VBF) HCP analysis");
+  if(channel==std::string("boost"     )) title = std::string("1-Jet");
+  if(channel==std::string("boost+0jet")) title = std::string("1-Jet");
+  if(channel==std::string("boost-mvis")) title = std::string("1-Jet (with m_{vis})");
+  if(channel==std::string("boost-ichep")) title = std::string("1-Jet (HCP on ICHEP dataset)");
+  if(channel==std::string("btag"      )) title = std::string("B-Tag");
+  if(channel==std::string("nobtag"    )) title = std::string("No B-Tag");
+  if(channel==std::string("hgg"       )) title = std::string("H#rightarrow#gamma#gamma");
+  if(channel==std::string("hww"       )) title = std::string("H#rightarrowWW#rightarrow2l2#nu");
+  if(channel==std::string("hmm"       )) title = std::string("H#rightarrow#mu#mu");
+  if(channel==std::string("hbb"       )) title = std::string("H#rightarrowbb");
+  if(channel==std::string("ltt"       )) title = std::string("WH#rightarrow#tau_{h}#tau_{h}+l");
+  if(channel==std::string("llt"       )) title = std::string("WH#rightarrow#tau_{h}+2l");
+  if(channel==std::string("4l"        )) title = std::string("ZH#rightarrow2l2#tau");
+  if(channel==std::string("ltt"       )) title = std::string("WH#rightarrow#tau_{h}#tau_{h}");
+  if(channel==std::string("llt"       )) title = std::string("WH#rightarrow#tau_{h}+2l (10 fb^{-1})");
+  if(channel==std::string("4l"        )) title = std::string("ZH#rightarrow2l2#tau (10 fb^{-1})");
+  if(channel==std::string("hzz4l"     )) title = std::string("H#rightarrowZZ#rightarrow4l");
+  if(channel==std::string("hzz2l2q"   )) title = std::string("H#rightarrowZZ#rightarrow2l2q");
+  if(channel==std::string("hzz2l2t"   )) title = std::string("H#rightarrowZZ#rightarrow2l2#tau");
+  if(channel==std::string("hzz2l2n"   )) title = std::string("H#rightarrowZZ#rightarrow2l2#nu");
+  if(channel==std::string("ggH"       )) title = std::string("gg#rightarrow#phi (bbH profiled)");
+  if(channel==std::string("bbH"       )) title = std::string("gg#rightarrowbb#phi (ggH profiled)");
+  if(channel==std::string("mvis"      )) title = std::string("Visible mass");
+  if(channel==std::string("ichep"     )) title = std::string("On ICHEP dataset");
+  if(channel==std::string("test-0"    )) title = std::string("gg#rightarrow#phi (bbH set to 0)");
+  if(channel==std::string("test-1"    )) title = std::string("gg#rightarrowbb#phi (ggH set to 0)");
+  if(channel==std::string("test-2"    )) title = std::string("gg#rightarrowbb#phi (w/o prefit)");
+  if(channel==std::string("test-3"    )) title = std::string("gg#rightarrow#phi (w/o prefit)");
+  if(channel==std::string("test-4"    )) title = std::string("Test-4");
+  if(channel==std::string("test-5"    )) title = std::string("Test-5");
+  if(channel==std::string("old"       )) title = std::string("Old Limit");
+  if(channel==std::string("cmb-5fb"   )) title = std::string("All channels (5 fb^{-1})");
+  if(channel==std::string("hpa-5fb"   )) title = std::string("HPA analyses (5 fb^{-1})");
+  if(channel==std::string("hpa-10fb"  )) title = std::string("HPA analyses (10 fb^{-1})");
+  if(channel==std::string("saeff"     )) title = std::string("small #alpha_{eff}");
+  if(channel==std::string("gluph"     )) title = std::string("gluo-phobic");
+  if(channel==std::string("nomix-200" )) title = std::string("no mixing (#mu=-200 GeV)");
+  if(channel==std::string("nomix+200" )) title = std::string("no mixing (#mu=+200 GeV)");
+  if(channel==std::string("mhmax-400" )) title = std::string("m_{h, max} (#mu=-400 GeV)");
+  if(channel==std::string("mhmax-200" )) title = std::string("m_{h, max} (#mu=-200 GeV)");
+  if(channel==std::string("mhmax+200" )) title = std::string("m_{h, max} (#mu=+200 GeV)");
+  if(channel==std::string("mhmax+400" )) title = std::string("m_{h, max} (#mu=+400 GeV)");
+  if(channel==std::string("mhmax+600" )) title = std::string("m_{h, max} (#mu=+600 GeV)");
+  if(channel==std::string("mhmax+800" )) title = std::string("m_{h, max} (#mu=+800 GeV)");
+  if(channel==std::string("MSSM-7TeV" )) title = std::string("ICHEP 7 TeV (4.9 fb^{-1})");
+  if(channel==std::string("MSSM-8TeV" )) title = std::string("ICHEP 8 TeV (5.1 fb^{-1})");
+  if(channel==std::string("HIG-11-020")) title = std::string("HIG-11-020 (1.6 fb^{-1})");
+  if(channel==std::string("HIG-11-020")) title = std::string("HIG-11-020 (1.6 fb^{-1})");
+  if(channel==std::string("HIG-11-029")) title = std::string("HIG-11-029 (4.9 fb^{-1})");
+  if(channel==std::string("HIG-12-018")) title = std::string("HIG-12-018 (10 fb^{-1})");
+  if(channel==std::string("HIG-12-032")) title = std::string("HIG-12-032 (5-10 fb^{-1})");
+  if(channel==std::string("HIG-12-043")) title = std::string("HIG-12-043 (17 fb^{-1})");
+  if(channel==std::string("HIG-12-050")) title = std::string("HIG-12-050 (17 fb^{-1})"); 
+  if(channel==std::string("mm-thomas"   )) title = std::string("mm thomas");
+  if(channel==std::string("em-MIT")) title = std::string("em MIT");
+  if(channel==std::string("em-IMPERIAL"   )) title = std::string("em IMPERIAL");
+  if(channel==std::string("tt-CERN ")) title = std::string("tt CERN");
+  if(channel==std::string("tt-MIT"     )) title = std::string("tt MIT");
+  if(channel==std::string("et-WISCONSIN"     )) title = std::string("et WISCONSIN");
+  if(channel==std::string("et-jose"     )) title = std::string("et jose");
+  if(channel==std::string("et-IMPERIAL"   )) title = std::string("et IMPERIAL");
+  if(channel==std::string("mt-WISCONSIN"     )) title = std::string("mt WISCONSIN");
+  if(channel==std::string("mt-jose"     )) title = std::string("mt jose");
+  if(channel==std::string("mt-IMPERIAL"   )) title = std::string("mt IMPERIAL");
+  if(channel==std::string("mt-matthew"  )) title = std::string("mt matthew");
+  if(channel==std::string("mt-aruna"    )) title = std::string("mt aruna");
+  if(channel==std::string("et-vbf-josh"     )) title = std::string("et vbf josh");
+  if(channel==std::string("et-vbf-jose"     )) title = std::string("et vbf jose");
+  if(channel==std::string("et-vbf-andrew"   )) title = std::string("et vbf andrew");
+  if(channel==std::string("mt-vbf-josh"     )) title = std::string("mt vbf josh");
+  if(channel==std::string("mt-vbf-jose"     )) title = std::string("mt vbf jose");
+  if(channel==std::string("mt-vbf-andrew"   )) title = std::string("mt vbf andrew");
+  if(channel==std::string("et-boost-josh"     )) title = std::string("et boost josh");
+  if(channel==std::string("et-boost-jose"     )) title = std::string("et boost jose");
+  if(channel==std::string("et-boost-andrew"   )) title = std::string("et boost andrew");
+  if(channel==std::string("mt-boost-josh"     )) title = std::string("mt boost josh");
+  if(channel==std::string("mt-boost-jose"     )) title = std::string("mt boost jose");
+  if(channel==std::string("mt-boost-andrew"   )) title = std::string("mt boost andrew");
+  return title;
+}
+
+void compareDeltaLimit(const char* filename, const char* channelstr, bool expected, bool observed, const char* type, double minimum=0., double maximum=20., const char* label=" Preliminary, H#rightarrowhh#rightarrow#tau#taubb, 19.8 fb^{-1} at 8TeV")
+{
+  SetStyle();
+
+  std::map<std::string, unsigned int> colors;
+  colors["incl"       ] = kBlue;
+  colors["0jet"       ] = kBlue;
+  colors["0jet-mvis"  ] = kBlue+2;
+  colors["0jet-ichep" ] = kBlue+2;
+  colors["2jet"       ] = kMagenta;
+  colors["vbf"        ] = kRed;
+  colors["vbf+0jet"   ] = kRed;
+  colors["vbf-mvis"   ] = kRed+2;
+  colors["vbf-ichep"  ] = kRed+2;
+  colors["boost"      ] = kGreen;
+  colors["boost+0jet" ] = kGreen;
+  colors["boost-mvis" ] = kGreen+2;
+  colors["boost-ichep"] = kGreen+2;
+  colors["btag"       ] = kRed;
+  colors["nobtag"     ] = kBlue;
+  colors["emu"        ] = kBlue;
+  colors["em"         ] = kBlue;
+  colors["em-mvis"    ] = kBlue+2;
+  colors["em-ichep"   ] = kBlue+2;
+  colors["etau"       ] = kRed;
+  colors["et"         ] = kRed;
+  colors["et-mvis"    ] = kRed+2;
+  colors["et-ichep"   ] = kRed+2;
+  colors["mutau"      ] = kGreen;
+  colors["mt"         ] = kGreen;
+  colors["mt-mvis"    ] = kGreen+2;
+  colors["mt-ichep"   ] = kGreen+2;
+  colors["mumu"       ] = kMagenta;
+  colors["mm"         ] = kMagenta;
+  colors["mm-mvis"    ] = kMagenta+2;
+  colors["mm-ichep"   ] = kMagenta+2;
+  colors["tautau"     ] = kOrange;
+  colors["tt"         ] = kOrange;
+  colors["tt-mvis"    ] = kOrange+2;
+  colors["tt-ichep"   ] = kOrange+2;
+  colors["vhtt"       ] = kMagenta+2;
+  colors["whtt"       ] = kMagenta+0;
+  colors["zhtt"       ] = kCyan+2;
+  colors["whhh"       ] = kBlue;
+  colors["cmb"        ] = kBlack;
+  colors["cmb-mvis"   ] = kGray+2;
+  colors["cmb-ichep"  ] = kGray+3;
+  colors["cmb+"       ] = kGray+2;
+  colors["htt"        ] = kBlack;
+  colors["htt+"       ] = kBlue;
+  colors["hgg"        ] = kRed;
+  colors["hww"        ] = kGreen;
+  colors["hbb"        ] = kOrange;
+  colors["hmm"        ] = kViolet;
+  colors["4l"         ] = kGreen;
+  colors["llt"        ] = kRed;
+  colors["ltt"        ] = kBlue;
+  colors["hzz4l"      ] = kBlue;
+  colors["hzz2l2q"    ] = kMagenta;
+  colors["hzz2l2q+"   ] = kMagenta;
+  colors["hzz2l2t"    ] = kOrange;
+  colors["hzz2l2n"    ] = kPink;
+  colors["ggH"        ] = kRed;
+  colors["bbH"        ] = kBlue;
+  colors["mvis"       ] = kBlue+2;
+  colors["ichep"      ] = kBlue+2;
+  colors["test-0"     ] = kRed+2;
+  colors["test-1"     ] = kGreen+2;
+  colors["test-2"     ] = kGreen;
+  colors["test-3"     ] = kRed+2;
+  colors["test-4"     ] = kBlue;
+  colors["test-5"     ] = kViolet-6;
+  colors["old"        ] = kViolet-6;
+  colors["cmb-5fb"    ] = kBlue;
+  colors["hpa-5fb"    ] = kRed;
+  colors["hpa-10fb"   ] = kBlack;
+  colors["saeff"      ] = kGreen;
+  colors["gluph"      ] = kOrange-3;
+  colors["nomix-200"  ] = kBlue-10;
+  colors["nomix+200"  ] = kBlue +2;
+  colors["mhmax-400"  ] = kGray +2;
+  colors["mhmax-200"  ] = kGray +1;
+  colors["mhmax+200"  ] = kMagenta+ 4;
+  colors["mhmax+400"  ] = kMagenta+ 3;
+  colors["mhmax+600"  ] = kMagenta- 2;
+  colors["mhmax+800"  ] = kMagenta-10;
+  colors["MSSM-7TeV"  ] = kBlue+2;
+  colors["MSSM-8TeV"  ] = kBlue+4;
+  colors["HIG-11-020" ] = kBlue+2;
+  colors["HIG-11-029" ] = kRed+2;
+  colors["HIG-12-018" ] = kBlue;
+  colors["HIG-12-032" ] = kRed+2;
+  colors["HIG-12-043" ] = kBlack;
+  colors["HIG-12-050" ] = kBlack;
+  colors["mm-thomas"   ] = kRed;
+  colors["tt-CERN" ] = kRed;
+  colors["tt-MIT"     ] = kBlue;
+  colors["em-MIT"] = kBlue;
+  colors["em-IMPERIAL"   ] = kRed;
+  colors["et-WISCONSIN"     ] = kRed;
+  colors["et-jose"     ] = kBlue;
+  colors["et-IMPERIAL"   ] = kBlue;
+  colors["mt-WISCONSIN"     ] = kRed;
+  colors["mt-jose"     ] = kRed;
+  colors["mt-IMPERIAL"   ] = kBlue;
+  colors["mt-matthew"  ] = kOrange;
+  colors["mt-aruna"    ] = kGreen+2;
+  colors["et-vbf-josh"     ] = kRed;
+  colors["et-vbf-jose"     ] = kBlue;
+  colors["et-vbf-andrew"   ] = kOrange;
+  colors["mt-vbf-josh"     ] = kViolet;
+  colors["mt-vbf-jose"     ] = kRed;
+  colors["mt-vbf-andrew"   ] = kBlue;
+  colors["et-boost-josh"     ] = kRed;
+  colors["et-boost-jose"     ] = kBlue;
+  colors["et-boost-andrew"   ] = kOrange;
+  colors["mt-boost-josh"     ] = kViolet;
+  colors["mt-boost-jose"     ] = kRed;
+  colors["mt-boost-andrew"   ] = kBlue; 
+
+  std::cout << " *******************************************************************************************************\n"
+	    << " * Usage     : root -l                                                                                  \n"
+	    << " *             .x <path>/compareDeltaLimit.C+(file, chn, exp, obs, type, min, max)                      \n"
+	    << " *                                                                                                      \n"
+	    << " * Arguments :  + file     const char*      full path to the input file                                 \n"
+	    << " *              + chn      const char*      list of channels; choose between: 'cmb', 'htt', 'emu',      \n"
+	    << " *                                          'etau', 'mutau', 'mumu', 'vhtt', 'hgg', 'hww', 'ggH',       \n"
+	    << " *                                          'bbH', 'nomix[-200, +200]', 'mhmax[-400, -200, +200]'       \n"
+	    << " *                                          'mhmax[+400, +600, +800]', 'test-0...5', 'saeff', 'gluph'   \n"
+	    << " *                                          The list should be comma separated and may contain          \n"
+	    << " *                                          whitespaces                                                 \n"
+	    << " *              + exp       bool            compare expected limits                                     \n"
+	    << " *              + obs       bool            compare observed limits                                     \n"
+	    << " *              + type      const char*     type of plot; choose between 'sm-xsec', 'mssm-xsec' and     \n"
+	    << " *                                          'mssm-tanb'                                                 \n"
+	    << " *              + max       double          maximum of the plot (default is 20.)                        \n"
+	    << " *                                                                                                      \n"
+	    << " *              + min       double          minimum of the plot (default is  0.)                        \n"
+	    << " *                                                                                                      \n"
+	    << " *******************************************************************************************************\n";
+
+  /// open input file  
+  TFile* inputFile = new TFile(filename); if(inputFile->IsZombie()){ std::cout << "ERROR:: file: " << filename << " does not exist.\n"; }
+
+  /// prepare input parameters
+  std::vector<std::string> channels;
+  string2Vector(cleanupWhitespaces(channelstr), channels);
+
+  /// prepare histograms
+  std::vector<TGraph*> hobs, hexp;
+  for(unsigned i=0; i<channels.size(); ++i){
+    if(observed) hobs.push_back(get<TGraph>(inputFile, std::string(channels[i]).append("/observed").c_str()));
+    if(expected) hexp.push_back(get<TGraph>(inputFile, std::string(channels[i]).append("/expected").c_str()));
+  }
+  
+  /// comparison of absolute differences between analysis is only possible if only two are given
+  if(expected){
+    if(hexp.size()!=2){
+      std::cout<<"comparison of absolute differences between analysis is only possible if only two channels are given"<<std::endl;
+      return;
+    }
+  }
+  if(observed){
+    if(hobs.size()!=2){
+      std::cout<<"comparison of absolute differences between analysis is only possible if only two channels are given"<<std::endl;
+      return;
+    }
+  }
+
+  /// do the drawing
+  TCanvas* canv1 = new TCanvas("canv1", "Limit Comparison", 600, 600);
+  canv1->cd();
+  canv1->SetGridx(1);
+  canv1->SetGridy(1);
+ 
+  TGraph *result= new TGraph();
+  result->SetMaximum(maximum);
+  result->SetMinimum(minimum);
+      
+  double x1, x2;
+  double y1, y2;
+  if(observed){
+    int k = hobs[0]->GetN();
+    for(int l=0; l<k; l++){
+      hobs[0]->GetPoint(l, x1, y1);
+      hobs[1]->GetPoint(l, x2, y2);
+      result->SetPoint(l, x1, TMath::Abs(y1-y2)*2/(y1+y2));
+      //std::cout<< l << " " <<  x1 <<" " <<TMath::Abs(y1-y2)*2/(y1+y2)<< std::endl;
+      }
+    }
+  if(expected){
+    int k = hexp[0]->GetN();
+    for(int l=0; l<k; l++){
+      hexp[0]->GetPoint(l, x1, y1);
+      hexp[1]->GetPoint(l, x2, y2);
+      result->SetPoint(l, x1, TMath::Abs(y1-y2)*2/(y1+y2));
+      //std::cout<< l << " " <<  x1 <<" " <<TMath::Abs(y1-y2)*2/(y1+y2)<< std::endl;
+      }
+    }
+  // format x-axis
+  std::string x_title;
+  if(std::string(type).find("mssm-tanb")!=std::string::npos){
+    x_title = std::string("m_{A} [GeV]");
+  }
+  else if (std::string(type).find("mssm-tanb")!=std::string::npos){
+    x_title = std::string("m_{#phi} [GeV]");
+  }
+ else {
+    x_title = std::string("m_{H} [GeV]");
+  } 
+  result->GetXaxis()->SetTitle(x_title.c_str());
+  result->GetXaxis()->SetLabelFont(62);
+  result->GetXaxis()->SetTitleFont(62);
+  result->GetXaxis()->SetTitleColor(1);
+  result->GetXaxis()->SetTitleOffset(1.05);  
+  std::string y_title = std::string("#Delta_{relative}(95% CL limit on #sigma#timesBR(H#rightarrowhh#rightarrowbb#tau#tau))");   
+  result->GetYaxis()->SetTitle(y_title.c_str());
+  result->GetYaxis()->SetLabelFont(62);
+  result->GetYaxis()->SetTitleOffset(1.5);
+  result->GetYaxis()->SetTitleSize(0.045); 
+  result->GetYaxis()->SetLabelSize(0.03); 
+  if(expected) result->GetXaxis()->SetLimits(hexp[0]->GetX()[0]-.1, hexp[0]->GetX()[hexp[0]->GetN()-1]+.1);
+  if(observed) result->GetXaxis()->SetLimits(hobs[0]->GetX()[0]-.1, hobs[0]->GetX()[hobs[0]->GetN()-1]+.1);
+  result->SetLineStyle(11.);
+  result->SetLineWidth( 3.); 
+  if(expected) result->SetLineColor(kRed);
+  if(observed) result->SetLineColor(kBlue);
+  result->SetMarkerStyle(20);
+  result->SetMarkerSize(MARKER_SIZE);
+  if(expected) result->SetMarkerColor(kRed);
+  if(observed) result->SetMarkerColor(kBlue);
+  result->Draw("APL");
+
+
+  canv1->RedrawAxis();
+  TLegend* leg1;
+  if(observed || expected){
+    if(expected && observed){
+      /// setup the CMS Preliminary
+      CMSPrelim(label, "", 0.15, 0.835);
+      leg1 = new TLegend(0.27, 0.75, 0.9, 0.9);
+    }
+    else if(observed){
+      /// setup the CMS Preliminary
+      CMSPrelim(label, "", 0.15, 0.835);
+      leg1 = new TLegend(0.27, 0.75, 0.9, 0.9);
+    }
+    else if(expected){
+      /// setup the CMS Preliminary
+      CMSPrelim(label, "", 0.15, 0.835);
+      leg1 = new TLegend(0.27, 0.75, 0.9, 0.9);
+    }
+    
+    leg1->SetTextSize(0.035);
+    leg1->SetBorderSize( 0 );
+    leg1->SetFillStyle ( 1001 );
+    //leg1->SetFillColor ( 0 );
+    leg1->SetFillColor (kWhite);
+    if(expected && observed) leg1->SetHeader( "#bf{Observed and Expected Limit}" );
+    else if(expected) leg1->SetHeader( "#bf{Expected Limit}" );
+    else if(observed) leg1->SetHeader( "#bf{Observed Limit}" );
+    // skip one of the two split options
+    TString help = TString::Format("#frac{2|%s - %s|}{%s + %s}" , channels[0].c_str(), channels[1].c_str(), channels[0].c_str(), channels[1].c_str());
+    leg1->AddEntry( result , help,  "PL" );    
+    leg1->Draw("same");
+  }
+
+  canv1->Print(std::string("singleLimits").append(expected ? "_expected" : "").append(observed ? "_observed" : "").append(std::string(type).find("mssm")!=std::string::npos ? "_mssm.png" : "_sm.png").c_str());
+  canv1->Print(std::string("singleLimits").append(expected ? "_expected" : "").append(observed ? "_observed" : "").append(std::string(type).find("mssm")!=std::string::npos ? "_mssm.pdf" : "_sm.pdf").c_str());
+  canv1->Print(std::string("singleLimits").append(expected ? "_expected" : "").append(observed ? "_observed" : "").append(std::string(type).find("mssm")!=std::string::npos ? "_mssm.pdf" : "_sm.eps").c_str());
+  return;
+}

--- a/python/layouts/limit-mssm-ggHTohh.py
+++ b/python/layouts/limit-mssm-ggHTohh.py
@@ -5,7 +5,7 @@ layout = cms.PSet(
     dataset = cms.string("CMS, H#rightarrow#tau#tau, 19.7 fb^{-1} at 8 TeV"),	
     #dataset = cms.string("CMS Preliminary, H #rightarrow #tau #tau, 18.3 fb^{-1} at 8 TeV"),
     ## extra labels (below legend)
-    extra = cms.string("A#rightarrowZh profiled"),	
+    #extra = cms.string("A#rightarrowZh profiled"),	
     #extra = cms.string("gg#rightarrow#phi bb set to zero"),
     ## x-axis title
     xaxis = cms.string("m_{H} [GeV]"),

--- a/python/tanb_grid.py
+++ b/python/tanb_grid.py
@@ -12,6 +12,8 @@ model_opts.add_option("--parameter1", dest="parameter1", default="", type="strin
                        help="The value of the free parameter in the model. Mue (higgs/higgsino mass parameter) Default: \"\"]")
 model_opts.add_option("--tanb", dest="tanb", default="", type="string",
                        help="The value of tanb in the model. Default: \"\"]")
+model_opts.add_option("--postfit", dest="postfit", default=False, action="store_true",
+                      help="If making postfit plots, parameter1 is mH (not mA) so needs to be transformed to mH")
 model_opts.add_option("--model", dest="modelname", default="mhmodp", type="string",
                        help="The model which should be used (choices are: mhmax-mu+200, mhmodp, mhmodm, lowmH, tauphobic, lightstau1, lightstopmod, low-tb-high, 2HDM_ty1_mA300_mH300, 2HDM_ty2_mA300_mH300). Default: \"mhmdop\"]")
 model_opts.add_option("--ana-type", dest="ana_type", default="Htautau", type="string",
@@ -197,7 +199,7 @@ def main() :
     card = parseCard(old_file, options)
     old_file.close()
     
-    if options.ana_type=="Hhh" and "2HDM" not in options.modelname : #mH has to be translated into mA to get the correct BR and xs from the model file
+    if options.ana_type=="Hhh" and options.postfit : #mH has to be translated into mA to get the correct BR and xs from the model file when making postfit plots
         neededParameter = mX_to_mA(card)
     else :
         neededParameter = options.parameter1   

--- a/test/fixmacros.sh
+++ b/test/fixmacros.sh
@@ -4,9 +4,7 @@ sed -i 's/HTT_TT_X/htt_tt_2_8TeV/g' htt_tt_2_8TeV.C
 sed -i 's/HHH_TT_X/htt_tt_0_8TeV/g' htt_tt_0_8TeV.C
 sed -i 's/HHH_TT_X/htt_tt_1_8TeV/g' htt_tt_1_8TeV.C
 sed -i 's/HHH_TT_X/htt_tt_2_8TeV/g' htt_tt_2_8TeV.C
-sed -i 's/HTT_MT_X/htt_mt_0_8TeV/g' htt_mt_0_8TeV.C
 sed -i 's/HTT_MT_X/htt_mt_1_8TeV/g' htt_mt_1_8TeV.C
 sed -i 's/HTT_MT_X/htt_mt_2_8TeV/g' htt_mt_2_8TeV.C
-sed -i 's/HTT_ET_X/htt_et_0_8TeV/g' htt_et_0_8TeV.C
 sed -i 's/HTT_ET_X/htt_et_1_8TeV/g' htt_et_1_8TeV.C
 sed -i 's/HTT_ET_X/htt_et_2_8TeV/g' htt_et_2_8TeV.C

--- a/test/mlfit_and_copy.py
+++ b/test/mlfit_and_copy.py
@@ -83,7 +83,7 @@ if options.analysis != "sm" :
     system("combineCards.py -S %s > datacards/tmp.txt" % optcards)
     system("perl -pi -e 's/datacards//g' datacards/{DATACARD}".format(DATACARD="tmp.txt"))
     system("perl -pi -e 's/common/root/g' datacards/{DATACARD}".format(DATACARD="tmp.txt"))
-    system("python {CMSSW_BASE}/src/HiggsAnalysis/HiggsToTauTau/python/tanb_grid.py --ana-type {ANA} --model mhmodp --parameter1 {MA} --tanb {TANB} datacards/{PATH}".format(
+    system("python {CMSSW_BASE}/src/HiggsAnalysis/HiggsToTauTau/python/tanb_grid.py --ana-type {ANA} --model mhmodp --parameter1 {MA} --tanb {TANB} --postfit datacards/{PATH}".format(
         CMSSW_BASE=os.environ['CMSSW_BASE'],
         ANA=options.analysis,
         MA=options.mA,

--- a/test/mlfit_and_copy.py
+++ b/test/mlfit_and_copy.py
@@ -9,6 +9,7 @@ parser.add_option("-s", "--skip", dest="skip", default=False, action="store_true
 parser.add_option("-a", "--analysis", dest="analysis", default="sm", type="string", help="Type of analysis (sm or mssm). Lower case is required. [Default: \"sm\"]")
 parser.add_option("--mm-discriminator", dest="mm_discriminator", default=False, action="store_true", help="Show the actual mm discriminator instead of the more intuitive msvfit plot. [Default: False]")
 parser.add_option("--mA", dest="mA", default="160", type="string", help="Mass of pseudoscalar mA only needed for mssm. [Default: '160']")
+parser.add_option("--mH", dest="mH", default="300", type="string", help="mH only needed for Hhh. [Default: '300']")
 parser.add_option("--tanb", dest="tanb", default="8", type="string", help="Tanb only needed for mssm. [Default: '8']")
 parser.add_option("--profile", dest="profile", default=False, action="store_true", help="Apply profiling of A->Zh and bbH in Hhh. [Default: False]")
 (options, args) = parser.parse_args()
@@ -83,12 +84,22 @@ if options.analysis != "sm" :
     system("combineCards.py -S %s > datacards/tmp.txt" % optcards)
     system("perl -pi -e 's/datacards//g' datacards/{DATACARD}".format(DATACARD="tmp.txt"))
     system("perl -pi -e 's/common/root/g' datacards/{DATACARD}".format(DATACARD="tmp.txt"))
-    system("python {CMSSW_BASE}/src/HiggsAnalysis/HiggsToTauTau/python/tanb_grid.py --ana-type {ANA} --model mhmodp --parameter1 {MA} --tanb {TANB} --postfit datacards/{PATH}".format(
-        CMSSW_BASE=os.environ['CMSSW_BASE'],
-        ANA=options.analysis,
-        MA=options.mA,
-        TANB=options.tanb,
-        PATH="tmp.txt"
-        ))
+    if options.analysis == "mssm" :
+        system("python {CMSSW_BASE}/src/HiggsAnalysis/HiggsToTauTau/python/tanb_grid.py --ana-type {ANA} --model mhmodp --parameter1 {MA} --tanb {TANB} --postfit datacards/{PATH}".format(
+            CMSSW_BASE=os.environ['CMSSW_BASE'],
+            ANA=options.analysis,
+            MA=options.mA,
+            TANB=options.tanb,
+            PATH="tmp.txt"
+            ))
+    elif options.analysis == "Hhh" :
+        system("python {CMSSW_BASE}/src/HiggsAnalysis/HiggsToTauTau/python/tanb_grid.py --ana-type {ANA} --model mhmodp --parameter1 {MA} --tanb {TANB} --postfit datacards/{PATH}".format(
+            CMSSW_BASE=os.environ['CMSSW_BASE'],
+            ANA=options.analysis,
+            MA=options.mH,
+            TANB=options.tanb,
+            PATH="tmp.txt"
+            ))
+
     system("rm datacards/tmp*")
 

--- a/test/produce_macros_Hhh.py
+++ b/test/produce_macros_Hhh.py
@@ -13,6 +13,7 @@ parser.add_option("-y", "--yields", dest="yields", default="1", type="int", help
 parser.add_option("-s", "--shapes", dest="shapes", default="1", type="int", help="Shift shape uncertainties. [Default: '1']")
 parser.add_option("--shapes-mm-special", dest="shapes_mm_special", default="0", type="int", help="Shift shape uncertainties in the mm channel. This option is needed to make an estimate on the additional stat. uncertainties in the mm channel when using the msv distribution instead of the actual 2-d discriminator folded to 1 dimonesion, which goes into hte limit calculation in the MSSM analysis. This option automatically switches the option --shapes to 0, as this option is not applicable in this case. [Default: '0']")
 parser.add_option("--mA", dest="mA", default="300", type="float", help="Mass of pseudoscalar mA only needed for mssm. [Default: '300']")
+parser.add_option("--mH", dest="mH", default="300", type="float", help="Mass of mH only needed for mssm. [Default: '300']")
 parser.add_option("--tanb", dest="tanb", default="2.5", type="float", help="Tanb only needed for mssm. [Default: '2.5']")
 parser.add_option("-u", "--uncertainties", dest="uncertainties", default="1", type="int", help="Set uncertainties of backgrounds. [Default: '1']")
 parser.add_option("-o", "--omit", dest="omit", default="0", type="int", help="Do not include uncertainty from original file. [Default: '0']")
@@ -146,6 +147,7 @@ class Analysis:
                  line = line.replace("$WJets", "break;")
              if(options.analysis=="Hhh") :
                  line = line.replace("$MA" , str(int(options.mA)))
+                 line = line.replace("$MH" , str(int(options.mH)))
                  line = line.replace("$TANB", str(int(options.tanb)))
 	     if options.uncertainties and (options.yields or options.shapes):
                  line = line.replace("$DRAW_ERROR", 'if(scaled) errorBand->Draw("e2same");')

--- a/test/produce_macros_Hhh.py
+++ b/test/produce_macros_Hhh.py
@@ -311,18 +311,32 @@ for chn in config.channels :
                                     "htt_{CHN}_{CAT}_{PER}.C".format(CHN=chn, CAT=cat, PER=per),
                                     options.profile
                                     )
-                elif options.profile:
+                elif options.profile and chn in ['mt','et'] :
                    plots = Analysis(options.analysis, histfile, config.categoryname[chn][per][config.categories[chn][per].index(cat)],
                                     process_weight, process_shape_weight, process_uncertainties, process_shape_uncertainties,
                                     "templates/HHH_{CHN}_X_Profile_template.C".format(CHN=chn.upper()),
                                     "htt_{CHN}_{CAT}_{PER}.C".format(CHN=chn, CAT=cat, PER=per),
                                     )
-                else :
+                elif chn in ['mt', 'et'] :
                    plots = Analysis(options.analysis,histfile,config.categoryname[chn][per][config.categories[chn][per].index(cat)],
                                     process_weight,process_shape_weight, process_uncertainties, process_shape_uncertainties,
                                     "templates/HHH_{CHN}_X_template.C".format(CHN=chn.upper()),
                                     "htt_{CHN}_{CAT}_{PER}.C".format(CHN=chn, CAT=cat, PER=per),
                                     )
+                elif chn == 'tt' :
+                   if cat in ['1','2'] :
+                       plots = Analysis(options.analysis,histfile,config.categoryname[chn][per][config.categories[chn][per].index(cat)],
+                                        process_weight,process_shape_weight, process_uncertainties, process_shape_uncertainties,
+                                        "templates/HHH_{CHN}_X_1or2tag_template.C".format(CHN=chn.upper()),
+                                        "htt_{CHN}_{CAT}_{PER}.C".format(CHN=chn, CAT=cat, PER=per),
+                                        )
+                   elif cat == '0' :
+                       plots = Analysis(options.analysis,histfile,config.categoryname[chn][per][config.categories[chn][per].index(cat)],
+                                        process_weight,process_shape_weight, process_uncertainties, process_shape_uncertainties,
+                                        "templates/HHH_{CHN}_X_notag_template.C".format(CHN=chn.upper()),
+                                        "htt_{CHN}_{CAT}_{PER}.C".format(CHN=chn, CAT=cat, PER=per),
+                                        )
+                 
             plots.run()
             scale_file=open("scales_{CHN}_{CAT}_{PER}.py".format(CHN=chn, CAT=cat, PER=per),'w')
             scale_file.write("scales="+str(plots.scale_output))

--- a/test/templates/HHH_ET_X_template.C
+++ b/test/templates/HHH_ET_X_template.C
@@ -511,7 +511,7 @@ HTT_ET_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   massA->SetTextColor(    1 );
   massA->SetTextFont (   62 );
   massA->AddText("MSSM m^{h}_{mod+} scenario");
-  massA->AddText("m_{A}=$MA GeV, tan#beta=$TANB");
+  massA->AddText("m_{H}=$MH GeV, tan#beta=$TANB");
   massA->Draw();
 #endif
 

--- a/test/templates/HHH_ET_X_template.C
+++ b/test/templates/HHH_ET_X_template.C
@@ -142,7 +142,7 @@ void rescale(TH1F* hin, unsigned int idx)
   $QCD
 #if defined MSSM
   case  8: // ggH
-  $ggHTohhTo2Tau2B$MA
+  $ggHTohhTo2Tau2B$MH
 /*
   case  9: // bbH
   $ggAToZhToLLBB$MA
@@ -200,7 +200,7 @@ HTT_ET_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   
   TFile* input = new TFile(inputfile.c_str());
 #ifdef MSSM
-  TFile* input2 = new TFile((inputfile+"_$MA_$TANB").c_str());
+  TFile* input2 = new TFile((inputfile+"_$MH_$TANB").c_str());
 #endif
   TH1F* Fakes  = refill((TH1F*)input->Get(TString::Format("%s/QCD"     , directory)), "QCD"); InitHist(Fakes, "", "", TColor::GetColor(250,202,255), 1001); 
   TH1F* EWK0   = refill((TH1F*)input->Get(TString::Format("%s/VV"      , directory)), "VV" ); InitHist(EWK0 , "", "", TColor::GetColor(222,90,106), 1001);
@@ -214,7 +214,7 @@ HTT_ET_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   TH1F* ttbar  = refill((TH1F*)input->Get(TString::Format("%s/TT"      , directory)), "TT" ); InitHist(ttbar, "", "", TColor::GetColor(155,152,204), 1001);
   TH1F* Ztt    = refill((TH1F*)input->Get(TString::Format("%s/ZTT"     , directory)), "ZTT"); InitHist(Ztt  , "", "", TColor::GetColor(248,206,104), 1001);
 #ifdef MSSM
-  TH1F* ggHTohhTo2Tau2B    = refill((TH1F*)input2->Get(TString::Format("%s/ggHTohhTo2Tau2B$MA" , directory)), "ggHTohhTo2Tau2B"); InitSignal(ggHTohhTo2Tau2B); ggHTohhTo2Tau2B->Scale($TANB*SIGNAL_SCALE);
+  TH1F* ggHTohhTo2Tau2B    = refill((TH1F*)input2->Get(TString::Format("%s/ggHTohhTo2Tau2B$MH" , directory)), "ggHTohhTo2Tau2B"); InitSignal(ggHTohhTo2Tau2B); ggHTohhTo2Tau2B->Scale($TANB*SIGNAL_SCALE);
 /*
   TH1F* ggAToZhToLLTauTau = refill((TH1F*)input2->Get(TString::Format("%s/ggAToZhToLLTauTau$MA", directory)), "ggAToZhToLLTauTau"); InitSignal(ggAToZhToLLTauTau); ggAToZhToLLTauTau->Scale(SIGNAL_SCALE);
   TH1F* ggAToZhToLLBB = refill((TH1F*)input2->Get(TString::Format("%s/ggAToZhToLLBB$MA", directory)),"ggAToZhToLLBB"); InitSignal(ggAToZhToLLBB); ggAToZhToLLBB->Scale(SIGNAL_SCALE);
@@ -511,7 +511,7 @@ HTT_ET_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   massA->SetTextColor(    1 );
   massA->SetTextFont (   62 );
   massA->AddText("MSSM m^{h}_{mod+} scenario");
-  massA->AddText("m_{H}=$MA GeV, tan#beta=$TANB");
+  massA->AddText("m_{A}=$MA GeV, tan#beta=$TANB");
   massA->Draw();
 #endif
 

--- a/test/templates/HHH_MT_X_template.C
+++ b/test/templates/HHH_MT_X_template.C
@@ -518,7 +518,7 @@ HTT_MT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   massA->SetTextColor(    1 );
   massA->SetTextFont (   62 );
   massA->AddText("MSSM m^{h}_{mod+} scenario");
-  massA->AddText("m_{A}=$MA GeV, tan#beta=$TANB");
+  massA->AddText("m_{H}=$MA GeV, tan#beta=$TANB");
   massA->Draw();
 #endif
 
@@ -571,10 +571,17 @@ HTT_MT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
     test1->SetBinContent(ibin+1, test1->GetBinContent(ibin+1)*test1->GetBinWidth(ibin+1));
     test1->SetBinError  (ibin+1, test1->GetBinError  (ibin+1)*test1->GetBinWidth(ibin+1));
   }
-  double chi2prob = test1->Chi2Test      (model,"PUW");        std::cout << "chi2prob:" << chi2prob << std::endl;
-  double chi2ndof = test1->Chi2Test      (model,"CHI2/NDFUW"); std::cout << "chi2ndf :" << chi2ndof << std::endl;
-  double ksprob   = test1->KolmogorovTest(model);              std::cout << "ksprob  :" << ksprob   << std::endl;
-  double ksprobpe = test1->KolmogorovTest(model,"DX");         std::cout << "ksprobpe:" << ksprobpe << std::endl;  
+  double chi2prob =0.;
+  double chi2ndof = 0.;
+  double ksprob=0.;
+  double ksprobpe=0.;
+ 
+if(!BLIND_DATA){
+  chi2prob = test1->Chi2Test      (model,"PUW");        std::cout << "chi2prob:" << chi2prob << std::endl;
+  chi2ndof = test1->Chi2Test      (model,"CHI2/NDFUW"); std::cout << "chi2ndf :" << chi2ndof << std::endl;
+  ksprob   = test1->KolmogorovTest(model);              std::cout << "ksprob  :" << ksprob   << std::endl;
+  ksprobpe = test1->KolmogorovTest(model,"DX");         std::cout << "ksprobpe:" << ksprobpe << std::endl;  
+}
 
   std::vector<double> edges;
   TH1F* zero = (TH1F*)ref->Clone("zero"); zero->Clear();
@@ -594,11 +601,13 @@ HTT_MT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   }
   float range = 0.1;
   std::sort(edges.begin(), edges.end());
+if(edges.size()>1){
   if (edges[edges.size()-2]>0.1) { range = 0.2; }
   if (edges[edges.size()-2]>0.2) { range = 0.5; }
   if (edges[edges.size()-2]>0.5) { range = 1.0; }
   if (edges[edges.size()-2]>1.0) { range = 1.5; }
   if (edges[edges.size()-2]>1.5) { range = 2.0; }
+}
   rat1->SetLineColor(kBlack);
   rat1->SetFillColor(kGray );
   rat1->SetMaximum(+range);
@@ -621,7 +630,9 @@ HTT_MT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   stat1->SetTextSize ( 0.05 );
   stat1->SetTextColor(    1 );
   stat1->SetTextFont (   62 );
+if(!BLIND_DATA){
   stat1->AddText(TString::Format("#chi^{2}/ndf=%.3f,  P(#chi^{2})=%.3f", chi2ndof, chi2prob));
+}
   //stat1->AddText(TString::Format("#chi^{2}/ndf=%.3f,  P(#chi^{2})=%.3f, P(KS)=%.3f", chi2ndof, chi2prob, ksprob));
   stat1->Draw();
 
@@ -648,11 +659,13 @@ HTT_MT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   }
   range = 0.1;
   std::sort(edges.begin(), edges.end());
+if(edges.size()>1){
   if (edges[edges.size()-2]>0.1) { range = 0.2; }
   if (edges[edges.size()-2]>0.2) { range = 0.5; }
   if (edges[edges.size()-2]>0.5) { range = 1.0; }
   if (edges[edges.size()-2]>1.0) { range = 1.5; }
   if (edges[edges.size()-2]>1.5) { range = 2.0; }
+}
 #if defined MSSM
   if(!log){ rat2->GetXaxis()->SetRange(200, rat2->FindBin(UPPER_EDGE)); } else{ rat2->GetXaxis()->SetRange(200, rat2->FindBin(UPPER_EDGE)); };
 #else

--- a/test/templates/HHH_MT_X_template.C
+++ b/test/templates/HHH_MT_X_template.C
@@ -140,7 +140,7 @@ void rescale(TH1F* hin, unsigned int idx)
   $QCD
 #if defined MSSM
   case  8: // ggH
-  $ggHTohhTo2Tau2B$MA
+  $ggHTohhTo2Tau2B$MH
 /*
   case 9:
   $ggAToZhToLLTauTau$MA
@@ -192,7 +192,7 @@ HTT_MT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   // open example histogram file
   TFile* input = new TFile(inputfile.c_str());
 #ifdef MSSM
-  TFile* input2 = new TFile((inputfile+"_$MA_$TANB").c_str());
+  TFile* input2 = new TFile((inputfile+"_$MH_$TANB").c_str());
 #endif
   TH1F* Fakes  = refill((TH1F*)input->Get(TString::Format("%s/QCD"     , directory)), "QCD"); InitHist(Fakes, "", "", TColor::GetColor(250,202,255), 1001);
   TH1F* EWK1   = refill((TH1F*)input->Get(TString::Format("%s/W"       , directory)), "W"  ); InitHist(EWK1 , "", "", TColor::GetColor(222,90,106), 1001);
@@ -211,7 +211,7 @@ HTT_MT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   TH1F* ggAToZhToLLBB = refill((TH1F*)input2->Get(TString::Format("%s/ggAToZhToLLBB$MA", directory)), "ggAToZHToLLBB"); InitSignal(ggAToZhToLLBB);ggAToZhToLLBB->Scale($TANB);
   TH1F* bbH    = refill((TH1F*)input2->Get(TString::Format("%s/bbH$MA" , directory)), "bbH"); InitSignal(bbH); bbH->Scale($TANB);
 */
-  TH1F* ggHTohhTo2Tau2B    = refill((TH1F*)input2->Get(TString::Format("%s/ggHTohhTo2Tau2B$MA" , directory)), "ggHTohhTo2Tau2B"); InitSignal(ggHTohhTo2Tau2B); ggHTohhTo2Tau2B->Scale($TANB*SIGNAL_SCALE);
+  TH1F* ggHTohhTo2Tau2B    = refill((TH1F*)input2->Get(TString::Format("%s/ggHTohhTo2Tau2B$MH" , directory)), "ggHTohhTo2Tau2B"); InitSignal(ggHTohhTo2Tau2B); ggHTohhTo2Tau2B->Scale($TANB*SIGNAL_SCALE);
 /*
   TH1F* ggAToZhToLLTauTau = refill((TH1F*)input2->Get(TString::Format("%s/ggAToZhToLLTauTau$MA", directory)), "ggAToZHToLLTauTau"); InitSignal(ggAToZhToLLTauTau); ggAToZhToLLTauTau->Scale(SIGNAL_SCALE);
   TH1F* ggAToZhToLLBB = refill((TH1F*)input2->Get(TString::Format("%s/ggAToZhToLLBB$MA", directory)), "ggAToZHToLLBB"); InitSignal(ggAToZhToLLBB); ggAToZhToLLBB->Scale(SIGNAL_SCALE);
@@ -518,7 +518,7 @@ HTT_MT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   massA->SetTextColor(    1 );
   massA->SetTextFont (   62 );
   massA->AddText("MSSM m^{h}_{mod+} scenario");
-  massA->AddText("m_{H}=$MA GeV, tan#beta=$TANB");
+  massA->AddText("m_{A}=$MA GeV, tan#beta=$TANB");
   massA->Draw();
 #endif
 

--- a/test/templates/HHH_MT_X_template.C
+++ b/test/templates/HHH_MT_X_template.C
@@ -518,7 +518,7 @@ HTT_MT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   massA->SetTextColor(    1 );
   massA->SetTextFont (   62 );
   massA->AddText("MSSM m^{h}_{mod+} scenario");
-  massA->AddText("m_{A}=$MA GeV, tan#beta=$TANB");
+  massA->AddText("m_{H}=$MH GeV, tan#beta=$TANB");
   massA->Draw();
 #endif
 

--- a/test/templates/HHH_TT_X_1or2tag_template.C
+++ b/test/templates/HHH_TT_X_1or2tag_template.C
@@ -145,13 +145,13 @@ void rescale(TH1F* hin, unsigned int idx)
   $QCD
 #if defined MSSM
   case  8: // ggH
-  $ggHTohhTo2Tau2B$MA
+  $ggHTohhTo2Tau2B$MH
   /*case  9:
-  $ggAToZhToLLTauTau$MA
+  $ggAToZhToLLTauTau$MH
   case 10:
-  $ggAToZhToLLBB$MA
+  $ggAToZhToLLBB$MH
   case  11: // bbH
-  $bbH$MA
+  $bbH$MH
 */
 #endif
   default :
@@ -193,7 +193,7 @@ HHH_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   // open example histogram file
   TFile* input = new TFile(inputfile.c_str());
 #ifdef MSSM
-  TFile* input2 = new TFile((inputfile+"_$MA_$TANB").c_str());
+  TFile* input2 = new TFile((inputfile+"_$MH_$TANB").c_str());
 #endif
   TH1F* Fakes  = refill((TH1F*)input->Get(TString::Format("%s/QCD"     , directory)), "QCD"); InitHist(Fakes, "", "", TColor::GetColor(250,202,255), 1001);
 //  TH1F* EWK1   = refill((TH1F*)input->Get(TString::Format("%s/W"       , directory)), "W"  ); InitHist(EWK1 , "", "", TColor::GetColor(222,90,106), 1001);
@@ -203,11 +203,11 @@ HHH_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   TH1F* ttbar  = refill((TH1F*)input->Get(TString::Format("%s/TT"      , directory)), "TT" ); InitHist(ttbar, "", "", TColor::GetColor(155,152,204), 1001);
   TH1F* Ztt    = refill((TH1F*)input->Get(TString::Format("%s/ZTT"     , directory)), "ZTT"); InitHist(Ztt  , "", "", TColor::GetColor(248,206,104), 1001);
 #ifdef MSSM
-  TH1F* ggHTohhTo2Tau2B    = refill((TH1F*)input2->Get(TString::Format("%s/ggHTohhTo2Tau2B$MA" , directory)), "ggHTohhTo2Tau2B"); InitSignal(ggHTohhTo2Tau2B); ggHTohhTo2Tau2B->Scale($TANB*SIGNAL_SCALE);
+  TH1F* ggHTohhTo2Tau2B    = refill((TH1F*)input2->Get(TString::Format("%s/ggHTohhTo2Tau2B$MH" , directory)), "ggHTohhTo2Tau2B"); InitSignal(ggHTohhTo2Tau2B); ggHTohhTo2Tau2B->Scale($TANB*SIGNAL_SCALE);
 /*
-  TH1F* ggAToZhToLLTauTau = refill((TH1F*)input2->Get(TString::Format("%s/ggAToZhToLLTauTau$MA",directory)),"ggAToZhToLLTauTau"); InitSignal(ggAToZhToLLTauTau);
-  TH1F* ggAToZhToLLBB = refill((TH1F*)input2->Get(TString::Format("%s/ggAToZhToLLBB$MA",directory)),"ggAToZhToLLBB"); InitSignal(ggAToZhToLLBB);
-  TH1F* bbH    = refill((TH1F*)input2->Get(TString::Format("%s/bbH$MA" , directory)), "bbH"); InitSignal(bbH);
+  TH1F* ggAToZhToLLTauTau = refill((TH1F*)input2->Get(TString::Format("%s/ggAToZhToLLTauTau$MH",directory)),"ggAToZhToLLTauTau"); InitSignal(ggAToZhToLLTauTau);
+  TH1F* ggAToZhToLLBB = refill((TH1F*)input2->Get(TString::Format("%s/ggAToZhToLLBB$MH",directory)),"ggAToZhToLLBB"); InitSignal(ggAToZhToLLBB);
+  TH1F* bbH    = refill((TH1F*)input2->Get(TString::Format("%s/bbH$MH" , directory)), "bbH"); InitSignal(bbH);
 */
 #endif
 #ifdef ASIMOV
@@ -251,8 +251,8 @@ HHH_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
     ttbar = refill(shape_histos(ttbar, datacard, "TT"), "TT"); 
     Ztt   = refill(shape_histos(Ztt, datacard, "ZTT"), "ZTT"); 
 #ifdef MSSM
-    ggH = refill(shape_histos(ggH, datacard, "ggH$MA"), "ggH$MA"); 
-    bbH = refill(shape_histos(bbH, datacard, "bbH$MA"), "bbH$MA"); 
+    ggH = refill(shape_histos(ggH, datacard, "ggH$MH"), "ggH$MH"); 
+    bbH = refill(shape_histos(bbH, datacard, "bbH$MH"), "bbH$MH"); 
 #else
     ggH = refill(shape_histos(ggH, datacard, "ggH"), "ggH");
     qqH = refill(shape_histos(qqH, datacard, "qqH"), "qqH");
@@ -441,7 +441,7 @@ HHH_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   massA->SetTextColor(    1 );
   massA->SetTextFont (   62 );
   massA->AddText("MSSM m^{h}_{mod+} scenario");
-  massA->AddText("m_{H}=$MA GeV, tan#beta=$TANB");
+  massA->AddText("m_{A}=$MA GeV, tan#beta=$TANB");
   massA->Draw();
 #endif
   

--- a/test/templates/HHH_TT_X_1or2tag_template.C
+++ b/test/templates/HHH_TT_X_1or2tag_template.C
@@ -441,7 +441,7 @@ HHH_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   massA->SetTextColor(    1 );
   massA->SetTextFont (   62 );
   massA->AddText("MSSM m^{h}_{mod+} scenario");
-  massA->AddText("m_{A}=$MA GeV, tan#beta=$TANB");
+  massA->AddText("m_{H}=$MH GeV, tan#beta=$TANB");
   massA->Draw();
 #endif
   

--- a/test/templates/HHH_TT_X_1or2tag_template.C
+++ b/test/templates/HHH_TT_X_1or2tag_template.C
@@ -1,3 +1,4 @@
+
 #include <iostream>
 #include <algorithm>
 
@@ -22,12 +23,10 @@
 static const float SIGNAL_SCALE = 10.;
 
 $DEFINE_ASIMOV
-$DEFINE_DROP_SIGNAL
-$DEFINE_EXTRA_SAMPLES
 $DEFINE_MSSM
 
 /**
-   \class   HTT_ET_X_template HTT_ET_X_template.C "HiggsAnalysis/HiggsToTauTau/postfit/tamplates/HTT_ET_X_template.C"
+   \class   HTT_TT_X_template HTT_TT_X_template.C "HiggsAnalysis/HiggsToTauTau/postfit/templates/HTT_TT_X_template.C"
 
    \brief   macro template to create pre-/postfit plots of the inputs to the limit calculation
 
@@ -38,7 +37,7 @@ $DEFINE_MSSM
 
 static const bool BLIND_DATA = $BLIND; //false;
 static const bool FULLPLOTS = true; //true;
-static const bool CONVERVATIVE_CHI2 = false;
+static const bool CONSERVATIVE_CHI2 = false;
 static const float UPPER_EDGE = 1005; // 695; 1495;
 
 float blinding_SM(float mass){ return (100<mass && mass<150); }
@@ -68,7 +67,6 @@ TH1F* refill(TH1F* hin, const char* sample, bool data=false)
   }
   TH1F* hout = (TH1F*)hin->Clone(); hout->Clear();
   for(int i=0; i<hout->GetNbinsX(); ++i){
-    //hout->SetBinContent(i+1, hin->GetBinContent(i+1)/hin->GetBinWidth(i+1));
     if(data){
 #if defined MSSM
       hout->SetBinContent(i+1, BLIND_DATA && blinding_MSSM(hin->GetBinCenter(i+1)) ? 0. : hin->GetBinContent(i+1)/hin->GetBinWidth(i+1));
@@ -91,28 +89,38 @@ TH1F* shape_histos(TH1F* hin, const TString datacard, const TString name)
   use the proper histograms and errors including shpae uncertainties as provided by combine
 */
 {
+  //  for(int ii=1; ii<hin->GetNbinsX()+1; ii++){
+  //    std::cout << "Yuta, " << name << " " << datacard << " bin"  << ii << " => " << hin->GetBinContent(ii) << std::endl;
+  //  }
+
   TH1F* hout = (TH1F*)hin->Clone(); hout->Clear();
   TFile* mlfit = new TFile("fitresults/mlfit.root", "READ");
   TH1F* shape = (TH1F*)mlfit->Get(TString("shapes_fit_s/").Append(datacard).Append("/").Append(name)); // currently problems with data and hioggsprocesses -> different name
+
+  //  for(int ii=1; ii<hin->GetNbinsX()+1; ii++){
+  //    std::cout << "Yuta2, " << name << " " << datacard << " bin"  << ii << " => " << hin->GetBinContent(ii) << std::endl;
+  //  }
 
   if(shape==0) std::cout << " No histogram found for " << name << std::endl;
 
   //  for(int i=0; i<hout->GetNbinsX(); ++i)
   for(int i=1; i<hout->GetNbinsX()+1; i++)
   {
-
+    
     Float_t Norig = hin->GetBinContent(i)*hin->GetBinWidth(i);
     Float_t Nshape = shape->GetBinContent(i);
     Float_t scale_err = (Nshape==0) ? 1 : Norig/Nshape;
 
-    //    hout->SetBinContent(i,shape->GetBinContent(i));
+    //    std::cout << "Yuta " << i << " " << Norig << " " << Nshape << " " << scale_err << std::endl;
+
     hout->SetBinContent(i,hin->GetBinContent(i)*hin->GetBinWidth(i));
     hout->SetBinError(i,shape->GetBinError(i)*scale_err);
+    //    hout->SetBinContent(i,shape->GetBinContent(i));
+    //    hout->SetBinError(i,shape->GetBinError(i));
   }
   mlfit->Close();
   return hout;
 }
-
 
 void rescale(TH1F* hin, unsigned int idx)
 /*
@@ -125,47 +133,25 @@ void rescale(TH1F* hin, unsigned int idx)
   $ZTT
   case  2: // TT
   $TT
-  case  3: // W   [EWK1]
-  $W
-#if defined EXTRA_SAMPLES
-  case  4: // ZJ  [EWK2]
-  $ZJ
-  case  5: // ZL  [EWK ]
-  $ZL 
-#else
-  case  4: // ZLL [EWK ]
+  case  3: // W  [EWK1]
+//  $W
+  case  4: // ZLL [EWK2]
   $ZLL
-#endif
-  case  6: // VV  [EWK0]
+  case  5: // ZL [EWK3]
+  //$ZL
+  case  6: // VV [EWK ]
   $VV
   case  7: // QCD
   $QCD
 #if defined MSSM
   case  8: // ggH
   $ggHTohhTo2Tau2B$MA
-/*
-  case  9: // bbH
-  $ggAToZhToLLBB$MA
-  case 10:
+  /*case  9:
   $ggAToZhToLLTauTau$MA
-  case 11:
+  case 10:
+  $ggAToZhToLLBB$MA
+  case  11: // bbH
   $bbH$MA
-*/
-/*  // case 10: // ggH_SM125
-//   $ggH_SM125
-//   case 11  // qqH_SM125:
-//   $qqH_SM125
-//   case 12: // VH_SM125
-//   $VH_SM125
-#else
-#ifndef DROP_SIGNAL
- // case  8: // ggH
-  //${SM}ggH125
-  //case  9: // qqH
-  //${SM}qqH125
-  //case 10: // VH
-  //${SM}VH125
-#endif
 */
 #endif
   default :
@@ -174,58 +160,54 @@ void rescale(TH1F* hin, unsigned int idx)
 }
 
 void 
-//HTT_ET_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string inputfile="root/$HISTFILE", const char* directory="eleTau_$CATEGORY")
-HTT_ET_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string inputfile="root/$HISTFILE", const char* directory="eleTau_$CATEGORY")
+//HTT_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string inputfile="root/$HISTFILE", const char* directory="tauTau_$CATEGORY")
+HHH_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string inputfile="root/$HISTFILE", const char* directory="tauTau_$CATEGORY")
 {
   // defining the common canvas, axes pad styles
   SetStyle(); gStyle->SetLineStyleString(11,"20 10");
 
   // determine category tag
   const char* category = ""; const char* category_extra = ""; const char* category_extra2 = "";
-  if(std::string(directory) == std::string("eleTau_2jet0tag"             )){ category = "e#tau_{h}";          }
-  if(std::string(directory) == std::string("eleTau_2jet0tag"             )){ category_extra = "2-jet 0 b-tag";          }
-  if(std::string(directory) == std::string("eleTau_2jet1tag"             )){ category = "e#tau_{h}";          }
-  if(std::string(directory) == std::string("eleTau_2jet1tag"             )){ category_extra = "2-jet 1 b-tag";       }
-  if(std::string(directory) == std::string("eleTau_2jet2tag"             )){ category = "e#tau_{h}";          }
-  if(std::string(directory) == std::string("eleTau_2jet2tag"             )){ category_extra = "2-jet 2 b-tag";         }
+  if(std::string(directory) == std::string("tauTau_2jet0tag")){ category = "#tau_{h}#tau_{h}";           }
+  if(std::string(directory) == std::string("tauTau_2jet0tag")){ category_extra= "2-jet 0 b-tag";           }
+  if(std::string(directory) == std::string("tauTau_2jet1tag"  )){ category = "#tau_{h}#tau_{h}";           }
+  if(std::string(directory) == std::string("tauTau_2jet1tag"  )){ category_extra= "2-jet 1 b-tag";     }
+  if(std::string(directory) == std::string("tauTau_2jet2tag"  )){ category = "#tau_{h}#tau_{h}";           }
+  if(std::string(directory) == std::string("tauTau_2jet2tag"  )){ category_extra = "2-jet 2 b-tag";              }
 
   const char* dataset;
 #ifdef MSSM
   if(std::string(inputfile).find("7TeV")!=std::string::npos){dataset = "#scale[1.5]{CMS}  h,H,A#rightarrow#tau#tau                                 4.9 fb^{-1} (7 TeV)";}
-  if(std::string(inputfile).find("8TeV")!=std::string::npos){dataset = "#scale[1.5]{CMS}  h,H,A#rightarrow#tau#tau                                19.7 fb^{-1} (8 TeV)";}
+  if(std::string(inputfile).find("8TeV")!=std::string::npos){
+    if(std::string(directory).find("btag")!=std::string::npos){
+      dataset = "#scale[1.5]{CMS}  h,H,A#rightarrow#tau#tau                                18.3 fb^{-1} (8 TeV)";
+    }
+    else{
+      dataset = "#scale[1.5]{CMS}  h,H,A#rightarrow#tau#tau                                19.7 fb^{-1} (8 TeV)";
+    }
+  }
 #else
-  if(std::string(inputfile).find("7TeV")!=std::string::npos){dataset = "CMS, 4.9 fb^{-1} at 7 TeV";}
   if(std::string(inputfile).find("8TeV")!=std::string::npos){dataset = "CMS, 19.7 fb^{-1} at 8 TeV";}
 #endif
   
+  // open example histogram file
   TFile* input = new TFile(inputfile.c_str());
 #ifdef MSSM
   TFile* input2 = new TFile((inputfile+"_$MA_$TANB").c_str());
 #endif
-  TH1F* Fakes  = refill((TH1F*)input->Get(TString::Format("%s/QCD"     , directory)), "QCD"); InitHist(Fakes, "", "", TColor::GetColor(250,202,255), 1001); 
-  TH1F* EWK0   = refill((TH1F*)input->Get(TString::Format("%s/VV"      , directory)), "VV" ); InitHist(EWK0 , "", "", TColor::GetColor(222,90,106), 1001);
-  TH1F* EWK1   = refill((TH1F*)input->Get(TString::Format("%s/W"       , directory)), "W"  ); InitHist(EWK1 , "", "", TColor::GetColor(222,90,106), 1001);
-#ifdef EXTRA_SAMPLES
-  TH1F* EWK2   = refill((TH1F*)input->Get(TString::Format("%s/ZJ"      , directory)), "ZJ" ); InitHist(EWK2 , "", "", TColor::GetColor(100,182,232), 1001);
-  TH1F* EWK    = refill((TH1F*)input->Get(TString::Format("%s/ZL"      , directory)), "ZL" ); InitHist(EWK  , "", "", TColor::GetColor(100,182,232), 1001);
-#else
-  TH1F* EWK    = refill((TH1F*)input->Get(TString::Format("%s/ZLL"     , directory)), "ZLL"); InitHist(EWK  , "", "", TColor::GetColor(100,182,232), 1001);
-#endif
+  TH1F* Fakes  = refill((TH1F*)input->Get(TString::Format("%s/QCD"     , directory)), "QCD"); InitHist(Fakes, "", "", TColor::GetColor(250,202,255), 1001);
+//  TH1F* EWK1   = refill((TH1F*)input->Get(TString::Format("%s/W"       , directory)), "W"  ); InitHist(EWK1 , "", "", TColor::GetColor(222,90,106), 1001);
+  TH1F* EWK2   = refill((TH1F*)input->Get(TString::Format("%s/ZLL"      , directory)), "ZLL" ); InitHist(EWK2 , "", "", TColor::GetColor(222,90,106), 1001);
+//TH1F* EWK3   = refill((TH1F*)input->Get(TString::Format("%s/ZL"      , directory)), "ZL" ); InitHist(EWK3 , "", "", TColor::GetColor(222,90,106), 1001);
+  TH1F* EWK    = refill((TH1F*)input->Get(TString::Format("%s/VV"      , directory)), "VV" ); InitHist(EWK  , "", "", TColor::GetColor(222,90,106), 1001);
   TH1F* ttbar  = refill((TH1F*)input->Get(TString::Format("%s/TT"      , directory)), "TT" ); InitHist(ttbar, "", "", TColor::GetColor(155,152,204), 1001);
   TH1F* Ztt    = refill((TH1F*)input->Get(TString::Format("%s/ZTT"     , directory)), "ZTT"); InitHist(Ztt  , "", "", TColor::GetColor(248,206,104), 1001);
 #ifdef MSSM
   TH1F* ggHTohhTo2Tau2B    = refill((TH1F*)input2->Get(TString::Format("%s/ggHTohhTo2Tau2B$MA" , directory)), "ggHTohhTo2Tau2B"); InitSignal(ggHTohhTo2Tau2B); ggHTohhTo2Tau2B->Scale($TANB*SIGNAL_SCALE);
 /*
-  TH1F* ggAToZhToLLTauTau = refill((TH1F*)input2->Get(TString::Format("%s/ggAToZhToLLTauTau$MA", directory)), "ggAToZhToLLTauTau"); InitSignal(ggAToZhToLLTauTau); ggAToZhToLLTauTau->Scale(SIGNAL_SCALE);
-  TH1F* ggAToZhToLLBB = refill((TH1F*)input2->Get(TString::Format("%s/ggAToZhToLLBB$MA", directory)),"ggAToZhToLLBB"); InitSignal(ggAToZhToLLBB); ggAToZhToLLBB->Scale(SIGNAL_SCALE);
-  TH1F* bbH    = refill((TH1F*)input2->Get(TString::Format("%s/bbH$MA" , directory)), "bbH"); InitSignal(bbH); bbH->Scale(SIGNAL_SCALE);
-*/
-//  TH1F* ggH_SM125= refill((TH1F*)input->Get(TString::Format("%s/ggH_SM125"  , directory)), "ggH_SM125"); InitHist(ggH_SM125, "", "", kGreen+2, 1001);
- // TH1F* qqH_SM125= refill((TH1F*)input->Get(TString::Format("%s/qqH_SM125"  , directory)), "qqH_SM125"); InitHist(qqH_SM125, "", "", kGreen+2, 1001);
-  //TH1F* VH_SM125 = refill((TH1F*)input->Get(TString::Format("%s/VH_SM125"   , directory)), "VH_SM125" ); InitHist(VH_SM125, "", "", kGreen+2, 1001);
-/*#else
-#ifndef DROP_SIGNAL
-#endif
+  TH1F* ggAToZhToLLTauTau = refill((TH1F*)input2->Get(TString::Format("%s/ggAToZhToLLTauTau$MA",directory)),"ggAToZhToLLTauTau"); InitSignal(ggAToZhToLLTauTau);
+  TH1F* ggAToZhToLLBB = refill((TH1F*)input2->Get(TString::Format("%s/ggAToZhToLLBB$MA",directory)),"ggAToZhToLLBB"); InitSignal(ggAToZhToLLBB);
+  TH1F* bbH    = refill((TH1F*)input2->Get(TString::Format("%s/bbH$MA" , directory)), "bbH"); InitSignal(bbH);
 */
 #endif
 #ifdef ASIMOV
@@ -236,86 +218,60 @@ HTT_ET_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   InitHist(data, "#bf{m_{H} [GeV]}", "#bf{dN/dm_{H} [1/GeV]}"); InitData(data);
 
   TH1F* ref=(TH1F*)Fakes->Clone("ref");
-  ref->Add(EWK0 );
-  ref->Add(EWK1 );
-#ifdef EXTRA_SAMPLES
+//  ref->Add(EWK1 );
   ref->Add(EWK2 );
-#endif
-  ref->Add(EWK  );
+//ref->Add(EWK3 );
+  ref->Add(EWK );
   ref->Add(ttbar);
   ref->Add(Ztt  );
 
   double unscaled[8];
   unscaled[0] = Fakes->Integral();
   unscaled[1] = EWK  ->Integral();
-  unscaled[1]+= EWK0 ->Integral();
-  unscaled[1]+= EWK1 ->Integral();
-#ifdef EXTRA_SAMPLES
+//  unscaled[1]+= EWK1 ->Integral();
   unscaled[1]+= EWK2 ->Integral();
-#endif
+//unscaled[1]+= EWK3 ->Integral();
   unscaled[2] = ttbar->Integral();
   unscaled[3] = Ztt  ->Integral();
 #ifdef MSSM
-  unscaled[4] = ggHTohhTo2Tau2B->Integral();
+  unscaled[4] = ggHTohhTo2Tau2B  ->Integral();
 /*
   unscaled[5] = ggAToZhToLLTauTau->Integral();
   unscaled[6] = ggAToZhToLLBB->Integral();
   unscaled[7] = bbH  ->Integral();
-*/
-/*
-#else
-#ifndef DROP_SIGNAL
-#endif
 */
 #endif
 
   if(scaled){
 
 /*    Fakes = refill(shape_histos(Fakes, datacard, "QCD"), "QCD");
-    EWK0 = refill(shape_histos(EWK0, datacard, "VV"), "VV"); 
-    EWK1 = refill(shape_histos(EWK1, datacard, "W"), "W"); 
-#ifdef EXTRA_SAMPLES
-    EWK2 = refill(shape_histos(EWK2, datacard, "ZJ"), "ZJ");
-    EWK = refill(shape_histos(EWK, datacard, "ZL"), "ZL");
-#else
-    //    EWK = refill(shape_histos(EWK, datacard, "ZLL"), "ZLL");
-#endif
-    ttbar = refill(shape_histos(ttbar, datacard, "TT"), "TT");
-    Ztt = refill(shape_histos(Ztt, datacard, "ZTT"), "ZTT");
+    EWK1  = refill(shape_histos(EWK1, datacard, "W"), "W");
+    EWK2  = refill(shape_histos(EWK2, datacard, "ZJ"), "ZJ");
+    EWK   = refill(shape_histos(EWK, datacard, "VV"), "VV");
+    ttbar = refill(shape_histos(ttbar, datacard, "TT"), "TT"); 
+    Ztt   = refill(shape_histos(Ztt, datacard, "ZTT"), "ZTT"); 
 #ifdef MSSM
     ggH = refill(shape_histos(ggH, datacard, "ggH$MA"), "ggH$MA"); 
     bbH = refill(shape_histos(bbH, datacard, "bbH$MA"), "bbH$MA"); 
 #else
-#ifndef DROP_SIGNAL
-    ggH = refill(shape_histos(ggH, datacard, "ggH"), "ggH"); 
-    qqH = refill(shape_histos(qqH, datacard, "qqH"), "qqH"); 
-    VH = refill(shape_histos(VH, datacard, "VH"), "VH"); 
-#endif  
+    ggH = refill(shape_histos(ggH, datacard, "ggH"), "ggH");
+    qqH = refill(shape_histos(qqH, datacard, "qqH"), "qqH");
+    VH  = refill(shape_histos(VH, datacard, "VH"), "VH"); 
 #endif
 */
-
     rescale(Fakes, 7); 
-    rescale(EWK0 , 6); 
-    rescale(EWK1 , 3); 
-#ifdef EXTRA_SAMPLES
+    //rescale(EWK1 , 3); 
     rescale(EWK2 , 4); 
-    rescale(EWK  , 5);
-#else
-    rescale(EWK  , 4);
-#endif 
+  //rescale(EWK3 , 5);
+    rescale(EWK  , 6); 
     rescale(ttbar, 2); 
     rescale(Ztt  , 1);
 #ifdef MSSM
     rescale(ggHTohhTo2Tau2B  , 8); 
 /*
-    rescale(ggAToZhToLLTauTau  , 9);  
-    rescale(ggAToZhToLLBB, 10);
-    rescale(bbH,11);
-*/
-/*
-#else
-#ifndef DROP_SIGNAL
-#endif  
+    rescale(ggAToZhToLLTauTau,9);
+    rescale(ggAToZhToLLBB,10);
+    rescale(bbH  , 11);  
 */
 #endif
   }
@@ -325,11 +281,9 @@ HTT_ET_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   scales[0]->SetBinContent(1, unscaled[0]>0 ? (Fakes->Integral()/unscaled[0]-1.) : 0.);
   scales[1] = new TH1F("scales-EWK"  , "", 8, 0, 8);
   scales[1]->SetBinContent(2, unscaled[1]>0 ? ((EWK  ->Integral()
-					       +EWK0 ->Integral()
-					       +EWK1 ->Integral()
-#ifdef EXTRA_SAMPLES
+					       //+EWK1 ->Integral()
 					       +EWK2 ->Integral()
-#endif
+					      //+EWK3 ->Integral()
 						)/unscaled[1]-1.) : 0.);
   scales[2] = new TH1F("scales-ttbar", "", 8, 0, 8);
   scales[2]->SetBinContent(3, unscaled[2]>0 ? (ttbar->Integral()/unscaled[2]-1.) : 0.);
@@ -337,64 +291,49 @@ HTT_ET_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   scales[3]->SetBinContent(4, unscaled[3]>0 ? (Ztt  ->Integral()/unscaled[3]-1.) : 0.);
 #ifdef MSSM
   scales[4] = new TH1F("scales-ggHTohhTo2Tau2B"  , "", 8, 0, 8);
-  scales[4]->SetBinContent(5, unscaled[4]>0 ? (ggHTohhTo2Tau2B->Integral()/unscaled[4]-1.) : 0.);
+  scales[4]->SetBinContent(5, unscaled[4]>0 ? (ggHTohhTo2Tau2B  ->Integral()/unscaled[4]-1.) : 0.);
 /*
   scales[5] = new TH1F("scales-ggAToZhToLLTauTau"  , "", 8, 0, 8);
-  scales[5]->SetBinContent(6, unscaled[5]>0 ? (ggAToZhToLLTauTau ->Integral()/unscaled[5]-1.) : 0.);
+  scales[5]->SetBinContent(6, unscaled[5]>0 ? (ggAToZhToLLTauTau  ->Integral()/unscaled[5]-1.) : 0.);
   scales[6] = new TH1F("scales-ggAToZhToLLBB"  , "", 8, 0, 8);
-  scales[6]->SetBinContent(7, unscaled[6]>0 ? (ggAToZhToLLBB ->Integral()/unscaled[6]-1.) : 0.);
+  scales[6]->SetBinContent(7, unscaled[6]>0 ? (ggAToZhToLLBB  ->Integral()/unscaled[6]-1.) : 0.);
   scales[7] = new TH1F("scales-bbH"  , "", 8, 0, 8);
-  scales[7]->SetBinContent(8, unscaled[7]>0 ? (bbH ->Integral()/unscaled[7]-1.) : 0.);
-*/
-/*
-#else
-#ifndef DROP_SIGNAL
-#endif
+  scales[7]->SetBinContent(8, unscaled[7]>0 ? (bbH  ->Integral()/unscaled[7]-1.) : 0.);
 */
 #endif
 
 //#ifdef MSSM
-  //qqH_SM125->Add(ggH_SM125);
-  //VH_SM125->Add(qqH_SM125);
-  //Fakes->Add(VH_SM125);
+//  qqH_SM125->Add(ggH_SM125);
+ // VH_SM125->Add(qqH_SM125);
+ // Fakes->Add(VH_SM125);
 //#endif
   Fakes->Add(ttbar);
-  EWK0 ->Add(Fakes);
-  EWK1 ->Add(EWK0 );
-#ifdef EXTRA_SAMPLES
-  EWK2 ->Add(EWK1 );
+ // EWK1 ->Add(Fakes);
+  EWK2 ->Add(Fakes );
+//EWK3 ->Add(EWK2 );
+//EWK  ->Add(EWK3 );
   EWK  ->Add(EWK2 );
-#else
-  EWK  ->Add(EWK1 );
-#endif
+//  ttbar->Add(EWK  );
   Ztt  ->Add(EWK);
-/*#ifdef MSSM
-//  ggAToZhToLLBB->Add(ggAToZhToLLTauTau);
- // bbH->Add(ggAToZhToLLBB);
-  //ggHTohhTo2Tau2B ->Add(bbH);
-#endif
-  if(log){
-#ifdef MSSM
-    //ggH  ->Add(bbH);
-#else
-#ifndef DROP_SIGNAL
-#endif
-#endif
-  }
-  else{
-#ifdef MSSM
-    //bbH  ->Add(Ztt);
-    //ggH  ->Add(bbH);
-#else
-#ifndef DROP_SIGNAL
-    VH   ->Add(Ztt);
-    qqH  ->Add(VH );
-    ggH  ->Add(qqH);
+  //if(log){
+//#ifdef MSSM
+ //   ggH->Add(bbH);
+//#else
+ //   qqH->Add(VH );
+  //  ggH->Add(qqH);
+//#endif
+ // }
+  //else{
+//#ifdef MSSM    
+ //   bbH->Add(Ztt);
+  //  ggH->Add(bbH);
+//#else
+ //   VH ->Add(Ztt);
+  //  qqH->Add(VH );
+   // ggH->Add(qqH);
+//#endif
+ // }
 
-#endif
-#endif
-  }
-*/
   /*
     Mass plot before and after fit
   */
@@ -409,14 +348,10 @@ HTT_ET_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
 #endif
   data->SetNdivisions(505);
   data->SetMinimum(min);
-#ifndef DROP_SIGNAL
   data->SetMaximum(max>0 ? max : std::max(std::max(maximum(data, log), maximum(Ztt, log)), maximum(ggHTohhTo2Tau2B, log)));
-#else
-  data->SetMaximum(max>0 ? max : std::max(maximum(data, log), maximum(Ztt, log)));
-#endif
   data->Draw("e");
 
-  TH1F* errorBand = (TH1F*)Ztt ->Clone("errorBand");
+  TH1F* errorBand = (TH1F*)Ztt ->Clone();
   errorBand  ->SetMarkerSize(0);
   errorBand  ->SetFillColor(13);
   errorBand  ->SetFillStyle(3013);
@@ -429,38 +364,33 @@ HTT_ET_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   }
   if(log){
     Ztt  ->Draw("histsame");
+//    ttbar->Draw("histsame");
     EWK  ->Draw("histsame");
-    EWK1 ->Draw("histsame");
     Fakes->Draw("histsame");
     ttbar->Draw("histsame");
-#ifdef MSSM
-   // VH_SM125->Draw("histsame");
-#endif   
+//#ifdef MSSM
+//    VH_SM125->Draw("histsame");
+//#endif
     $DRAW_ERROR
-#ifndef DROP_SIGNAL
     ggHTohhTo2Tau2B  ->Draw("histsame");
-#endif
   }
   else{
     Ztt  ->Draw("histsame");
+//    ttbar->Draw("histsame");
     EWK  ->Draw("histsame");
-    EWK1 ->Draw("histsame");
     Fakes->Draw("histsame");
     ttbar->Draw("histsame");
-/*#ifdef MSSM
+#ifdef MSSM
     //VH_SM125->Draw("histsame");
 #endif
-*/
     $DRAW_ERROR
-#ifndef DROP_SIGNAL
-    ggHTohhTo2Tau2B->Draw("histsame");
-#endif
+    ggHTohhTo2Tau2B  ->Draw("histsame");
   }
   data->Draw("esame");
   canv->RedrawAxis();
 
-  //CMSPrelim(dataset, "#tau_{e}#tau_{h}", 0.17, 0.835);
-  CMSPrelim(dataset, "", 0.16, 0.835);
+  //CMSPrelim(dataset, "#tau_{h}#tau_{h}", 0.17, 0.835);
+  CMSPrelim(dataset, "", 0.16, 0.835);  
 #if defined MSSM
   TPaveText* chan     = new TPaveText(0.20, 0.74+0.061, 0.32, 0.74+0.161, "tlbrNDC");
   if (strcmp(category_extra2,"")!=0) chan     = new TPaveText(0.20, 0.69+0.061, 0.32, 0.74+0.161, "tlbrNDC");
@@ -481,8 +411,8 @@ HTT_ET_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   chan->AddText(category_extra2);
 #endif
   chan->Draw();
-
-/*  TPaveText* cat      = new TPaveText(0.20, 0.71+0.061, 0.32, 0.71+0.161, "NDC");
+/*
+  TPaveText* cat      = new TPaveText(0.20, 0.71+0.061, 0.32, 0.71+0.161, "NDC");
   cat->SetBorderSize(   0 );
   cat->SetFillStyle(    0 );
   cat->SetTextAlign(   12 );
@@ -514,23 +444,11 @@ HTT_ET_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   massA->AddText("m_{H}=$MA GeV, tan#beta=$TANB");
   massA->Draw();
 #endif
-
+  
 #ifdef MSSM
   TLegend* leg = new TLegend(0.53, 0.60, 0.95, 0.90);
   SetLegendStyle(leg);
-  leg->AddEntry(ggHTohhTo2Tau2B  , TString::Format("%.0f#timesH#rightarrowhhh#rightarrow#tau#taubb",SIGNAL_SCALE) , "L" );
-/*#else
-  TLegend* leg = new TLegend(0.52, 0.58, 0.92, 0.89);
-  SetLegendStyle(leg);
-#ifndef DROP_SIGNAL
-  if(SIGNAL_SCALE!=1){
-    leg->AddEntry(ggHTohhTo2Tau2B  , TString::Format("%.0f#timesH(125 GeV)#rightarrow#tau#tau", SIGNAL_SCALE) , "L" );
-  }
-  else{
-    leg->AddEntry(ggHTohhTo2Tau2B  , "SM H(125 GeV)#rightarrow#tau#tau" , "L" );
-  }
-#endif
-*/
+  leg->AddEntry(ggHTohhTo2Tau2B  , TString::Format("%0.f #times H#rightarrowhh#rightarrow#tau#taubb", SIGNAL_SCALE) , "L" );
 #endif
 #ifdef ASIMOV
   leg->AddEntry(data , "sum(bkg) + H(125)"              , "LP");
@@ -538,12 +456,11 @@ HTT_ET_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   leg->AddEntry(data , "Observed"                       , "LP");
 #endif
   leg->AddEntry(Ztt  , "Z#rightarrow#tau#tau"           , "F" );
-  leg->AddEntry(EWK  , "Z#rightarrow ee"                , "F" );
-  leg->AddEntry(EWK1 , "W+jets"                         , "F" );
+  leg->AddEntry(EWK  , "Electroweak"                    , "F" );
   leg->AddEntry(Fakes, "QCD"                            , "F" );
   leg->AddEntry(ttbar, "t#bar{t}"                       , "F" );
 /*#ifdef MSSM
-//  leg->AddEntry(VH_SM125, "SM H(125 GeV) #rightarrow #tau#tau", "F" );
+  leg->AddEntry(VH_SM125, "SM H(125 GeV) #rightarrow #tau#tau", "F" );
 #endif
 */
   $ERROR_LEGEND
@@ -562,10 +479,11 @@ HTT_ET_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   for(int ibin=0; ibin<test1->GetNbinsX(); ++ibin){
     //the small value in case of 0 entries in the model is added to prevent the chis2 test from failing
     model->SetBinContent(ibin+1, model->GetBinContent(ibin+1)>0 ? model->GetBinContent(ibin+1)*model->GetBinWidth(ibin+1) : 0.01);
-    model->SetBinError  (ibin+1, CONVERVATIVE_CHI2 ? 0. : model->GetBinError  (ibin+1)*model->GetBinWidth(ibin+1));
+    model->SetBinError  (ibin+1, CONSERVATIVE_CHI2 ? 0. : model->GetBinError  (ibin+1)*model->GetBinWidth(ibin+1));
     test1->SetBinContent(ibin+1, test1->GetBinContent(ibin+1)*test1->GetBinWidth(ibin+1));
     test1->SetBinError  (ibin+1, test1->GetBinError  (ibin+1)*test1->GetBinWidth(ibin+1));
   }
+
 double chi2prob=0.;
 double chi2ndof=0.;
 double ksprob=0.;
@@ -577,7 +495,6 @@ if(!BLIND_DATA){
   ksprob   = test1->KolmogorovTest(model);              std::cout << "ksprob  :" << ksprob   << std::endl;
   ksprobpe = test1->KolmogorovTest(model,"DX");         std::cout << "ksprobpe:" << ksprobpe << std::endl;  
 }
-
   std::vector<double> edges;
   TH1F* zero = (TH1F*)ref->Clone("zero"); zero->Clear();
   TH1F* rat1 = (TH1F*)data->Clone("rat1"); 
@@ -596,12 +513,12 @@ if(!BLIND_DATA){
   }
   float range = 0.1;
   std::sort(edges.begin(), edges.end());
-if(edges.size()>1){
+  if(edges.size()>1){
   if (edges[edges.size()-2]>0.1) { range = 0.2; }
-  if (edges[edges.size()-2]>0.2) { range = 0.5; }
-  if (edges[edges.size()-2]>0.5) { range = 1.0; }
-  if (edges[edges.size()-2]>1.0) { range = 1.5; }
-  if (edges[edges.size()-2]>1.5) { range = 2.0; }
+  else if (edges[edges.size()-2]>0.2) { range = 0.5; }
+  else if (edges[edges.size()-2]>0.5) { range = 1.0; }
+  else if (edges[edges.size()-2]>1.0) { range = 1.5; }
+  else if (edges[edges.size()-2]>1.5) { range = 2.0; }
 }
   rat1->SetLineColor(kBlack);
   rat1->SetFillColor(kGray );
@@ -694,30 +611,23 @@ if(edges.size()>1){
   InitHist  (scales[1], "", "", TColor::GetColor(222,90,106), 1001);
   InitHist  (scales[2], "", "", TColor::GetColor(155,152,204), 1001);
   InitHist  (scales[3], "", "", TColor::GetColor(248,206,104), 1001);
-#ifndef DROP_SIGNAL
-  InitSignal(scales[4]);
-/*
-  InitSignal(scales[5]);
-  InitSignal(scales[6]);
-  InitSignal(scales[7]);
+  InitHist(scales[4],"","",kGreen+2,1001);
+/*  InitHist(scales[5],"","",kGreen+2,1001);
+  InitHist(scales[6],"","",kGreen+2,1001);
+  InitHist(scales[7],"","",kGreen+2,1001);
 */
-#endif
+
   scales[0]->Draw();
   scales[0]->GetXaxis()->SetBinLabel(1, "#bf{Fakes}");
   scales[0]->GetXaxis()->SetBinLabel(2, "#bf{EWK}"  );
   scales[0]->GetXaxis()->SetBinLabel(3, "#bf{ttbar}");
   scales[0]->GetXaxis()->SetBinLabel(4, "#bf{Ztt}"  );
 #ifdef MSSM
-  scales[0]->GetXaxis()->SetBinLabel(5, "#bf{ggHTohhTo2Tau2B}"  );
+  scales[0]->GetXaxis()->SetBinLabel(5, "#bf{ggHTohhTo2tau2B}"  );
 /*
-  scales[0]->GetXaxis()->SetBinLabel(6, "#bf{ggAToZhToLLTauTau}"  );
-  scales[0]->GetXaxis()->SetBinLabel(7, "#bf{ggAToZhToLLBB}"      );
-  scales[0]->GetXaxis()->SetBinLabel(8, "#bf{bbH}");
-*/
-/*#else
-  scales[0]->GetXaxis()->SetBinLabel(5, "#bf{ggH}"  );
-  scales[0]->GetXaxis()->SetBinLabel(6, "#bf{qqH}"  );
-  scales[0]->GetXaxis()->SetBinLabel(7, "#bf{VH}"   );
+  scales[0]->GetXaxis()->SetBinLabel(6, "#bf{ggAToZhToLLTauTau}");
+  scales[0]->GetXaxis()->SetBinLabel(7, "#bf{ggAToZhToLLBB}");
+  scales[0]->GetXaxis()->SetBinLabel(8, "#bf{bbH}"  );
 */
 #endif
   scales[0]->SetMaximum(+0.5);
@@ -727,16 +637,10 @@ if(edges.size()>1){
   scales[1]->Draw("same");
   scales[2]->Draw("same");
   scales[3]->Draw("same");
-#ifdef MSSM
   scales[4]->Draw("same");
-/*#else
-#ifndef DROP_SIGNAL
-  scales[4]->Draw("same");
-  scales[5]->Draw("same");
+ /* scales[5]->Draw("same");
   scales[6]->Draw("same");
-#endif
 */
-#endif
   TH1F* zero_samples = (TH1F*)scales[0]->Clone("zero_samples"); zero_samples->Clear();
   zero_samples->SetBinContent(1,0.);
   zero_samples->Draw("same"); 
@@ -766,13 +670,10 @@ if(edges.size()>1){
   }
 
   TFile* output = new TFile(TString::Format("%s_%sfit_%s_%s.root", directory, scaled ? "post" : "pre", isSevenTeV ? "7TeV" : "8TeV", log ? "LOG" : "LIN"), "update");
-  output->cd();
+  output->cd(); 
   data ->Write("data_obs");
   Fakes->Write("Fakes"   );
-  EWK  ->Write("Zee"     );
-  EWK1 ->Write("EWK"    );
-  //EWK  ->Write("EWK"     );
-  EWK1 ->Write("EWK1"    );
+  EWK  ->Write("EWK"     );
   ttbar->Write("ttbar"   );
   Ztt  ->Write("Ztt"     );
 #ifdef MSSM
@@ -782,20 +683,7 @@ if(edges.size()>1){
   ggAToZhToLLBB->Write("ggAToZhToLLBB");
   bbH  ->Write("bbH"     );
 */
-//  ggH_SM125->Write("ggH_SM125");
- // qqH_SM125->Write("qqH_SM125");
-//  VH_SM125 ->Write("VH_SM125");
-/*#else
-#ifndef DROP_SIGNAL
-  ggH  ->Write("ggH"     );
-  qqH  ->Write("qqH"     );
-  VH   ->Write("VH"      );
 #endif
-*/
-#endif
-  if(errorBand){
-    errorBand->Write("errorBand");
-  }
   output->Close();
  
   delete errorBand;

--- a/test/templates/HHH_TT_X_notag_template.C
+++ b/test/templates/HHH_TT_X_notag_template.C
@@ -441,7 +441,7 @@ HHH_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   massA->SetTextColor(    1 );
   massA->SetTextFont (   62 );
   massA->AddText("MSSM m^{h}_{mod+} scenario");
-  massA->AddText("m_{A}=$MA GeV, tan#beta=$TANB");
+  massA->AddText("m_{H}=$MH GeV, tan#beta=$TANB");
   massA->Draw();
 #endif
   

--- a/test/templates/HHH_TT_X_notag_template.C
+++ b/test/templates/HHH_TT_X_notag_template.C
@@ -145,13 +145,13 @@ void rescale(TH1F* hin, unsigned int idx)
   $QCD
 #if defined MSSM
   case  8: // ggH
-  $ggHTohhTo2Tau2B$MA
+  $ggHTohhTo2Tau2B$MH
   /*case  9:
-  $ggAToZhToLLTauTau$MA
+  $ggAToZhToLLTauTau$MH
   case 10:
-  $ggAToZhToLLBB$MA
+  $ggAToZhToLLBB$MH
   case  11: // bbH
-  $bbH$MA
+  $bbH$MH
 */
 #endif
   default :
@@ -193,7 +193,7 @@ HHH_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   // open example histogram file
   TFile* input = new TFile(inputfile.c_str());
 #ifdef MSSM
-  TFile* input2 = new TFile((inputfile+"_$MA_$TANB").c_str());
+  TFile* input2 = new TFile((inputfile+"_$MH_$TANB").c_str());
 #endif
   TH1F* Fakes  = refill((TH1F*)input->Get(TString::Format("%s/QCD"     , directory)), "QCD"); InitHist(Fakes, "", "", TColor::GetColor(250,202,255), 1001);
   TH1F* EWK1   = refill((TH1F*)input->Get(TString::Format("%s/W"       , directory)), "W"  ); InitHist(EWK1 , "", "", TColor::GetColor(222,90,106), 1001);
@@ -203,11 +203,11 @@ HHH_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   TH1F* ttbar  = refill((TH1F*)input->Get(TString::Format("%s/TT"      , directory)), "TT" ); InitHist(ttbar, "", "", TColor::GetColor(155,152,204), 1001);
   TH1F* Ztt    = refill((TH1F*)input->Get(TString::Format("%s/ZTT"     , directory)), "ZTT"); InitHist(Ztt  , "", "", TColor::GetColor(248,206,104), 1001);
 #ifdef MSSM
-  TH1F* ggHTohhTo2Tau2B    = refill((TH1F*)input2->Get(TString::Format("%s/ggHTohhTo2Tau2B$MA" , directory)), "ggHTohhTo2Tau2B"); InitSignal(ggHTohhTo2Tau2B); ggHTohhTo2Tau2B->Scale($TANB*SIGNAL_SCALE);
+  TH1F* ggHTohhTo2Tau2B    = refill((TH1F*)input2->Get(TString::Format("%s/ggHTohhTo2Tau2B$MH" , directory)), "ggHTohhTo2Tau2B"); InitSignal(ggHTohhTo2Tau2B); ggHTohhTo2Tau2B->Scale($TANB*SIGNAL_SCALE);
 /*
-  TH1F* ggAToZhToLLTauTau = refill((TH1F*)input2->Get(TString::Format("%s/ggAToZhToLLTauTau$MA",directory)),"ggAToZhToLLTauTau"); InitSignal(ggAToZhToLLTauTau);
-  TH1F* ggAToZhToLLBB = refill((TH1F*)input2->Get(TString::Format("%s/ggAToZhToLLBB$MA",directory)),"ggAToZhToLLBB"); InitSignal(ggAToZhToLLBB);
-  TH1F* bbH    = refill((TH1F*)input2->Get(TString::Format("%s/bbH$MA" , directory)), "bbH"); InitSignal(bbH);
+  TH1F* ggAToZhToLLTauTau = refill((TH1F*)input2->Get(TString::Format("%s/ggAToZhToLLTauTau$MH",directory)),"ggAToZhToLLTauTau"); InitSignal(ggAToZhToLLTauTau);
+  TH1F* ggAToZhToLLBB = refill((TH1F*)input2->Get(TString::Format("%s/ggAToZhToLLBB$MH",directory)),"ggAToZhToLLBB"); InitSignal(ggAToZhToLLBB);
+  TH1F* bbH    = refill((TH1F*)input2->Get(TString::Format("%s/bbH$MH" , directory)), "bbH"); InitSignal(bbH);
 */
 #endif
 #ifdef ASIMOV
@@ -251,8 +251,8 @@ HHH_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
     ttbar = refill(shape_histos(ttbar, datacard, "TT"), "TT"); 
     Ztt   = refill(shape_histos(Ztt, datacard, "ZTT"), "ZTT"); 
 #ifdef MSSM
-    ggH = refill(shape_histos(ggH, datacard, "ggH$MA"), "ggH$MA"); 
-    bbH = refill(shape_histos(bbH, datacard, "bbH$MA"), "bbH$MA"); 
+    ggH = refill(shape_histos(ggH, datacard, "ggH$MH"), "ggH$MH"); 
+    bbH = refill(shape_histos(bbH, datacard, "bbH$MH"), "bbH$MH"); 
 #else
     ggH = refill(shape_histos(ggH, datacard, "ggH"), "ggH");
     qqH = refill(shape_histos(qqH, datacard, "qqH"), "qqH");
@@ -441,7 +441,7 @@ HHH_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   massA->SetTextColor(    1 );
   massA->SetTextFont (   62 );
   massA->AddText("MSSM m^{h}_{mod+} scenario");
-  massA->AddText("m_{H}=$MA GeV, tan#beta=$TANB");
+  massA->AddText("m_{A}=$MA GeV, tan#beta=$TANB");
   massA->Draw();
 #endif
   

--- a/test/templates/HHH_TT_X_notag_template.C
+++ b/test/templates/HHH_TT_X_notag_template.C
@@ -135,8 +135,8 @@ void rescale(TH1F* hin, unsigned int idx)
   $TT
   case  3: // W  [EWK1]
   $W
-  case  4: // ZJ [EWK2]
-  $ZJ
+  case  4: // ZLL [EWK2]
+  $ZLL
   case  5: // ZL [EWK3]
   //$ZL
   case  6: // VV [EWK ]
@@ -197,7 +197,7 @@ HHH_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
 #endif
   TH1F* Fakes  = refill((TH1F*)input->Get(TString::Format("%s/QCD"     , directory)), "QCD"); InitHist(Fakes, "", "", TColor::GetColor(250,202,255), 1001);
   TH1F* EWK1   = refill((TH1F*)input->Get(TString::Format("%s/W"       , directory)), "W"  ); InitHist(EWK1 , "", "", TColor::GetColor(222,90,106), 1001);
-  TH1F* EWK2   = refill((TH1F*)input->Get(TString::Format("%s/ZJ"      , directory)), "ZJ" ); InitHist(EWK2 , "", "", TColor::GetColor(222,90,106), 1001);
+  TH1F* EWK2   = refill((TH1F*)input->Get(TString::Format("%s/ZLL"      , directory)), "ZLL" ); InitHist(EWK2 , "", "", TColor::GetColor(222,90,106), 1001);
 //TH1F* EWK3   = refill((TH1F*)input->Get(TString::Format("%s/ZL"      , directory)), "ZL" ); InitHist(EWK3 , "", "", TColor::GetColor(222,90,106), 1001);
   TH1F* EWK    = refill((TH1F*)input->Get(TString::Format("%s/VV"      , directory)), "VV" ); InitHist(EWK  , "", "", TColor::GetColor(222,90,106), 1001);
   TH1F* ttbar  = refill((TH1F*)input->Get(TString::Format("%s/TT"      , directory)), "TT" ); InitHist(ttbar, "", "", TColor::GetColor(155,152,204), 1001);
@@ -441,7 +441,7 @@ HHH_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   massA->SetTextColor(    1 );
   massA->SetTextFont (   62 );
   massA->AddText("MSSM m^{h}_{mod+} scenario");
-  massA->AddText("m_{A}=$MA GeV, tan#beta=$TANB");
+  massA->AddText("m_{H}=$MA GeV, tan#beta=$TANB");
   massA->Draw();
 #endif
   
@@ -483,10 +483,17 @@ HHH_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
     test1->SetBinContent(ibin+1, test1->GetBinContent(ibin+1)*test1->GetBinWidth(ibin+1));
     test1->SetBinError  (ibin+1, test1->GetBinError  (ibin+1)*test1->GetBinWidth(ibin+1));
   }
-  double chi2prob = test1->Chi2Test      (model,"PUW");        std::cout << "chi2prob:" << chi2prob << std::endl;
-  double chi2ndof = test1->Chi2Test      (model,"CHI2/NDFUW"); std::cout << "chi2ndf :" << chi2ndof << std::endl;
-  double ksprob   = test1->KolmogorovTest(model);              std::cout << "ksprob  :" << ksprob   << std::endl;
-  double ksprobpe = test1->KolmogorovTest(model,"DX");         std::cout << "ksprobpe:" << ksprobpe << std::endl;  
+double chi2prob =0.;
+double chi2ndof=0.;
+double ksprob=0.;
+double ksprobpe=0.;
+
+if(!BLIND_DATA){
+  chi2prob = test1->Chi2Test      (model,"PUW");        std::cout << "chi2prob:" << chi2prob << std::endl;
+  chi2ndof = test1->Chi2Test      (model,"CHI2/NDFUW"); std::cout << "chi2ndf :" << chi2ndof << std::endl;
+  ksprob   = test1->KolmogorovTest(model);              std::cout << "ksprob  :" << ksprob   << std::endl;
+  ksprobpe = test1->KolmogorovTest(model,"DX");         std::cout << "ksprobpe:" << ksprobpe << std::endl;  
+}
 
   std::vector<double> edges;
   TH1F* zero = (TH1F*)ref->Clone("zero"); zero->Clear();
@@ -506,11 +513,13 @@ HHH_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   }
   float range = 0.1;
   std::sort(edges.begin(), edges.end());
+if(edges.size()>1){
   if (edges[edges.size()-2]>0.1) { range = 0.2; }
   if (edges[edges.size()-2]>0.2) { range = 0.5; }
   if (edges[edges.size()-2]>0.5) { range = 1.0; }
   if (edges[edges.size()-2]>1.0) { range = 1.5; }
   if (edges[edges.size()-2]>1.5) { range = 2.0; }
+}
   rat1->SetLineColor(kBlack);
   rat1->SetFillColor(kGray );
   rat1->SetMaximum(+range);
@@ -533,7 +542,9 @@ HHH_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   stat1->SetTextSize ( 0.05 );
   stat1->SetTextColor(    1 );
   stat1->SetTextFont (   62 );
+if(!BLIND_DATA){
   stat1->AddText(TString::Format("#chi^{2}/ndf=%.3f,  P(#chi^{2})=%.3f", chi2ndof, chi2prob));
+}
   //stat1->AddText(TString::Format("#chi^{2}/ndf=%.3f,  P(#chi^{2})=%.3f, P(KS)=%.3f", chi2ndof, chi2prob, ksprob));
   stat1->Draw();
 
@@ -560,11 +571,13 @@ HHH_TT_X(bool scaled=true, bool log=true, float min=0.1, float max=-1., string i
   }
   range = 0.1;
   std::sort(edges.begin(), edges.end());
+if(edges.size()>1){
   if (edges[edges.size()-2]>0.1) { range = 0.2; }
   if (edges[edges.size()-2]>0.2) { range = 0.5; }
   if (edges[edges.size()-2]>0.5) { range = 1.0; }
   if (edges[edges.size()-2]>1.0) { range = 1.5; }
   if (edges[edges.size()-2]>1.5) { range = 2.0; }
+}
 #if defined MSSM
   if(!log){ rat2->GetXaxis()->SetRange(200, rat2->FindBin(UPPER_EDGE)); } else{ rat2->GetXaxis()->SetRange(200, rat2->FindBin(UPPER_EDGE)); };
 #else


### PR DESCRIPTION
Layout/config file edits:
- asymptotic limit layout file no longer prints "A->Zh profiled" by default
- added a deltalimit comparison macro for Hhh (with correct plot title)
- removed 2jet0tag from config file for etau and mutau

Postfit plotting fixes:
- Added --postfit option to tanb_grid.py so that for postfit plotting the mH_to_mA function is used (still off for creating model dependent limits)
- KS and chi2 test not performed when blinded
- Fixed fully hadronic templates to match chosen background contributions and  names
- Scripts will now draw plots even if there is no data in the unblinded region