### PR TITLE
Updates including support for shapes as RooDataHist

### DIFF
--- a/CombineHarvester/CombineTools/interface/CombineHarvester.h
+++ b/CombineHarvester/CombineTools/interface/CombineHarvester.h
@@ -41,10 +41,37 @@ class CombineHarvester {
   /**@{*/
   CombineHarvester();
   ~CombineHarvester();
+
+  /**
+   * Copy constructor (makes a shallow copy)
+   *
+   * When copying a CombineHarvester instance it is important to remember that
+   * the stored Observation, Process, Systematic and Parameter objects
+   * themselves are not duplicated, rather their pointers are simply copied.
+   * This is called making a *shallow-copy*, and means modifying the contents
+   * of one of these objects in the copied CombineHarvester also modifies it
+   * for the original. However, filtering methods only affect the instance
+   * they are called from. For example, if all the signal Process entries are
+   * filtered from a copied CombineHarvester instance they will remain in the
+   * original instance.
+   */
   CombineHarvester(CombineHarvester const& other);
   CombineHarvester(CombineHarvester&& other);
   CombineHarvester& operator=(CombineHarvester other);
+
+  /**
+   * Creates and returns a shallow copy of the CombineHarvester instance
+   */
   CombineHarvester cp();
+
+  /**
+   * Creates and retunrs a deep copy of the CombineHarvester instance
+   *
+   * Unlike the shallow copy, a deep copy will duplicate every internal
+   * object, including any attached RooWorkspaces. This makes it completely
+   * independent of the original instance.
+   */
+  CombineHarvester deep();
   /**@}*/
 
   /**

--- a/CombineHarvester/CombineTools/interface/CombineHarvester.h
+++ b/CombineHarvester/CombineTools/interface/CombineHarvester.h
@@ -314,7 +314,8 @@ class CombineHarvester {
   StrPairVec GenerateShapeMapAttempts(std::string process,
       std::string category);
 
-  StrPair SetupWorkspace(HistMapping const& mapping);
+  StrPair SetupWorkspace(HistMapping const& mapping,
+                         std::string alt_mapping = "");
 
   void ImportParameters(RooArgSet *vars);
 
@@ -333,6 +334,8 @@ class CombineHarvester {
       std::string const& mass,
       std::string const& nuisance,
       unsigned type);
+
+void FillHistMappings(std::vector<HistMapping> & mappings);
 
   // ---------------------------------------------------------------
   // Private methods for shape/yield evaluation
@@ -356,6 +359,8 @@ class CombineHarvester {
 
   void ShapeDiff(double x, TH1F* target, TH1 const* nom, TH1 const* low,
                  TH1 const* high);
+  void ShapeDiff(double x, TH1F* target, RooDataHist const* nom,
+                 RooDataHist const* low, RooDataHist const* high);
 
   void CreateParameterIfEmpty(CombineHarvester *cmb, std::string const& name);
 };

--- a/CombineHarvester/CombineTools/interface/CombineHarvester.h
+++ b/CombineHarvester/CombineTools/interface/CombineHarvester.h
@@ -358,7 +358,7 @@ void FillHistMappings(std::vector<HistMapping> & mappings);
   }
 
   void ShapeDiff(double x, TH1F* target, TH1 const* nom, TH1 const* low,
-                 TH1 const* high);
+                 TH1 const* high, bool linear);
   void ShapeDiff(double x, TH1F* target, RooDataHist const* nom,
                  RooDataHist const* low, RooDataHist const* high);
 
@@ -468,7 +468,7 @@ void CombineHarvester::AddSyst(CombineHarvester& target,
       sys->set_asymm(valmap.IsAsymm());
       sys->set_value_u(valmap.ValU(procs_[i].get()));
       sys->set_value_d(valmap.ValD(procs_[i].get()));
-    } else if (type == "shape") {
+    } else if (type == "shape" || type == "shapeN2") {
       sys->set_asymm(true);
       sys->set_value_u(1.0);
       sys->set_value_d(1.0);

--- a/CombineHarvester/CombineTools/interface/Process.h
+++ b/CombineHarvester/CombineTools/interface/Process.h
@@ -5,6 +5,7 @@
 #include "TH1.h"
 #include "RooAbsPdf.h"
 #include "RooAbsReal.h"
+#include "RooAbsData.h"
 #include "CombineTools/interface/MakeUnique.h"
 
 namespace ch {
@@ -67,6 +68,9 @@ class Process {
   void set_pdf(RooAbsPdf* pdf) { pdf_ = pdf; }
   RooAbsPdf const* pdf() const { return pdf_; }
 
+  void set_data(RooAbsData* data) { data_ = data; }
+  RooAbsData const* data() const { return data_; }
+
   void set_norm(RooAbsReal* norm) { norm_ = norm; }
   RooAbsReal const* norm() const { return norm_; }
 
@@ -86,6 +90,7 @@ class Process {
   std::string mass_;
   std::unique_ptr<TH1> shape_;
   RooAbsPdf* pdf_;
+  RooAbsData* data_;
   RooAbsReal* norm_;
 
 

--- a/CombineHarvester/CombineTools/interface/Systematic.h
+++ b/CombineHarvester/CombineTools/interface/Systematic.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include "TH1.h"
+#include "RooDataHist.h"
 #include "CombineTools/interface/MakeUnique.h"
 
 namespace ch {
@@ -67,6 +68,13 @@ class Systematic {
   // void set_shape_d(std::unique_ptr<TH1> shape_d);
   TH1 const* shape_d() const { return shape_d_.get(); }
 
+  RooDataHist const* data_u() const { return data_u_; }
+
+  RooDataHist const* data_d() const { return data_d_; }
+
+  void set_data(RooDataHist* data_u, RooDataHist* data_d,
+                RooDataHist const* nominal);
+
   void set_shapes(std::unique_ptr<TH1> shape_u, std::unique_ptr<TH1> shape_d,
                   TH1 const* nominal);
 
@@ -90,6 +98,8 @@ class Systematic {
   std::string mass_;
   std::unique_ptr<TH1> shape_u_;
   std::unique_ptr<TH1> shape_d_;
+  RooDataHist * data_u_;
+  RooDataHist * data_d_;
 
   friend void swap(Systematic& first, Systematic& second);
 };

--- a/CombineHarvester/CombineTools/macros/plot_vhbb.C
+++ b/CombineHarvester/CombineTools/macros/plot_vhbb.C
@@ -1,0 +1,131 @@
+#include "interface/Plotting.h"
+#include "interface/Plotting_Style.h"
+
+void plot_vhbb(TString file, TString folder, TString output, TString title) {
+  ModTDRStyle();
+  TFile f(file);
+
+  TH1F *h_data  = (TH1F*)gDirectory->Get(folder+"data_obs");
+
+  TH1F *h_VVHF  = (TH1F*)gDirectory->Get(folder+"VVHF");
+  TH1F *h_VVLF  = (TH1F*)gDirectory->Get(folder+"VVLF");
+  TH1F *h_QCD   = (TH1F*)gDirectory->Get(folder+"QCD");
+  TH1F *h_s_Top = (TH1F*)gDirectory->Get(folder+"s_Top");
+  TH1F *h_TT    = (TH1F*)gDirectory->Get(folder+"TT");
+  TH1F *h_Zj0b  = (TH1F*)gDirectory->Get(folder+"Zj0b");
+  TH1F *h_Zj1b  = (TH1F*)gDirectory->Get(folder+"Zj1b");
+  TH1F *h_Zj2b  = (TH1F*)gDirectory->Get(folder+"Zj2b");
+  TH1F *h_Wj0b  = (TH1F*)gDirectory->Get(folder+"Wj0b");
+  TH1F *h_Wj1b  = (TH1F*)gDirectory->Get(folder+"Wj1b");
+  TH1F *h_Wj2b  = (TH1F*)gDirectory->Get(folder+"Wj2b");
+  TH1F *h_WH  = (TH1F*)gDirectory->Get(folder+"WH");
+  TH1F *h_ZH  = (TH1F*)gDirectory->Get(folder+"ZH");
+  h_WH->Add(h_ZH);
+
+  TH1F *h_bkg  = (TH1F*)gDirectory->Get(folder+"TotalBkg");
+
+  h_VVHF->SetFillColor(TColor::GetColor(194, 193, 194));
+  h_VVLF->SetFillColor(TColor::GetColor(83, 83, 83));
+  h_QCD->SetFillColor(TColor::GetColor(242, 0, 255));
+  h_s_Top->SetFillColor(TColor::GetColor(64, 255, 194));
+  h_TT->SetFillColor(TColor::GetColor(37, 2, 255));
+  h_Zj0b->SetFillColor(TColor::GetColor(194, 197, 8));
+  h_Zj1b->SetFillColor(TColor::GetColor(203, 199, 117));
+  h_Zj2b->SetFillColor(TColor::GetColor(255, 255, 8));
+  h_Wj0b->SetFillColor(TColor::GetColor(43, 139, 1));
+  h_Wj1b->SetFillColor(TColor::GetColor(140, 255, 83));
+  h_Wj2b->SetFillColor(TColor::GetColor(67, 255, 9));
+  h_WH->SetFillColor(TColor::GetColor(244, 0, 8));
+
+  TH1F *h_WHc = (TH1F*)h_WH->Clone();
+  h_WHc->SetLineColor(TColor::GetColor(244, 0, 8));
+  h_WHc->SetFillStyle(0);
+  h_WHc->SetLineWidth(2);
+
+  int new_idx = CreateTransparentColor(12, 0.4);
+  h_bkg->SetFillColor(new_idx);
+  h_bkg->SetMarkerSize(0);
+
+  THStack stack;
+  stack.Add(h_VVHF);
+  stack.Add(h_VVLF);
+  stack.Add(h_QCD);
+  stack.Add(h_s_Top);
+  stack.Add(h_TT);
+  stack.Add(h_Zj0b);
+  stack.Add(h_Zj1b);
+  stack.Add(h_Zj2b);
+  stack.Add(h_Wj0b);
+  stack.Add(h_Wj1b);
+  stack.Add(h_Wj2b);
+  stack.Add(h_WH);
+
+  TCanvas * canv = new TCanvas(output, output);
+  canv->cd();
+  std::vector<TPad*> pads = TwoPadSplit(0.29, 0.005, 0.005);
+
+  // Do the axis hist
+  std::vector<TH1*> h = CreateAxisHists(2, h_data);
+  SetupTwoPadSplitAsRatio(pads, h[0], h[1], "Obs/Exp", true, 0.05, 1.95);
+  h[1]->GetXaxis()->SetTitle("BDT output");
+  TString w_label = TString::Format("%.2f", h[1]->GetXaxis()->GetBinWidth(1));
+  h[0]->GetYaxis()->SetTitle("Events / " + w_label);
+
+  h[0]->Draw("axis");
+
+  // Draw the stack
+  stack.Draw("HISTSAME");
+  h_bkg->Draw("e2same");
+  h_data->Draw("esamex0");
+
+  TH1F *ratio = reinterpret_cast<TH1F *>(
+      MakeRatioHist(h_data, h_bkg, true, false));
+  TH1F *ratio_err = reinterpret_cast<TH1F *>(
+      MakeRatioHist(h_bkg, h_bkg, true, false));
+
+  pads[0]->SetLogy(true);
+  h[0]->SetMinimum(0.01);
+
+  // Fix the y-axis range
+  FixTopRange(pads[0], GetPadYMax(pads[0]), 0.45);
+
+  // Make the legend
+  TLegend *leg = PositionedLegend(0.5, 0.2, 3, 0.025);
+  leg->AddEntry(h_data, "Observed", "pe");
+  leg->AddEntry(h_TT, "tt", "F");
+  leg->AddEntry(h_Wj2b, "W + bb", "F");
+  leg->AddEntry(h_s_Top, "Single top", "F");
+  leg->AddEntry(h_Wj1b, "W + b", "F");
+  leg->AddEntry(h_QCD, "QCD", "F");
+  leg->AddEntry(h_Wj0b, "W + udscg", "F");
+  leg->AddEntry(h_VVLF, "VZ(udscg)", "F");
+  leg->AddEntry(h_Zj2b, "Z + bb", "F");
+  leg->AddEntry(h_VVHF, "VZ(bb)", "F");
+  leg->AddEntry(h_Zj1b, "Z + b", "F");
+  leg->AddEntry(h_WH, "VH", "F");
+  leg->AddEntry(h_Zj0b, "Z + udscg", "F");
+  leg->AddEntry(h_bkg, "Bkg. Uncertainty", "f");
+
+  leg->SetNColumns(2);
+  leg->Draw();
+
+  // Draw labels and text
+  // DrawCMSLogo(pads[0], "CombineHarvester", "", 0);
+  DrawTitle(pads[0], "CombineHarvester", 1);
+  DrawTitle(pads[0], title, 3);
+
+  // Redraw the axis
+  FixOverlay();
+  h_WHc->Draw("HISTSAME");
+
+  pads[1]->cd();
+  h[1]->Draw("axis");
+  ratio_err->Draw("e2same");
+  TLine line;
+  line.SetLineStyle(2);
+  DrawHorizontalLine(pads[1], &line, 1.0);
+  ratio->Draw("esamex0");
+
+  // Print!
+  canv->Print(output+".pdf");
+}

--- a/CombineHarvester/CombineTools/scripts/roundtrip.sh
+++ b/CombineHarvester/CombineTools/scripts/roundtrip.sh
@@ -1,0 +1,55 @@
+WORKAREA="output/roundtrip"
+DEF_MLFIT="--rMin=-5 --rMax=5 --X-rtd FITTER_NEW_CROSSING_ALGO --minimizerAlgoForMinos=Minuit2 --minimizerToleranceForMinos=0.1 --X-rtd FITTER_NEVER_GIVE_UP --X-rtd FITTER_BOUND --minimizerAlgo=Minuit2 --minimizerStrategy=0 --minimizerTolerance=0.1 --robustFit=1 --setPhysicsModelParameters MH=125 --freezeNuisances MH"
+mkdir -p ${WORKAREA}
+
+
+SOURCE_vhbb="output/cmshcg/summer2013/searches/vhbb/125"
+
+cd ${SOURCE_vhbb}
+combineCards.py \
+  vhbb_Wln_7TeV=vhbb_Wln_7TeV.txt \
+  vhbb_Wln_8TeV=vhbb_Wln_8TeV.txt \
+  vhbb_Wtn_8TeV=vhbb_Wtn_8TeV.txt \
+  vhbb_Zll_7TeV=vhbb_Zll_7TeV.txt \
+  vhbb_Zll_8TeV=vhbb_Zll_8TeV.txt \
+  vhbb_Znn_7TeV=vhbb_Znn_7TeV.txt \
+  vhbb_Znn_8TeV=vhbb_Znn_8TeV.txt &> vhbb_in.txt
+cd -
+
+./bin/RoundTrip -i ${SOURCE_vhbb}/vhbb_in.txt -o ${WORKAREA}/vhbb_out.txt -r ${WORKAREA}/vhbb_out.root -m 125 --print &> ${WORKAREA}/vhbb.log
+
+text2workspace.py -b ${SOURCE_vhbb}/vhbb_in.txt -o ${WORKAREA}/ws_vhbb_in.root  --default-morphing shape2 -m 125
+text2workspace.py -b ${WORKAREA}/vhbb_out.txt   -o ${WORKAREA}/ws_vhbb_out.root --default-morphing shape2 -m 125
+
+
+combine -M MaxLikelihoodFit ${DEF_MLFIT} --out=${WORKAREA} -m 125 ${WORKAREA}/ws_vhbb_in.root
+mv ${WORKAREA}/mlfit.root ${WORKAREA}/mlfit_vhbb_in.root
+combine -M MaxLikelihoodFit ${DEF_MLFIT} --out=${WORKAREA} -m 125 ${WORKAREA}/ws_vhbb_out.root
+mv ${WORKAREA}/mlfit.root ${WORKAREA}/mlfit_vhbb_out.root
+
+./bin/PostFitShapes -d ${WORKAREA}/vhbb_out.txt -o ${WORKAREA}/shapes_vhbb_out.root -m 125 -f ${WORKAREA}/mlfit_vhbb_out.root:fit_s --postfit --sampling --print
+
+
+SOURCE_hww2l2v="output/cmshcg/summer2013/searches/hww2l2v/125"
+
+cd ${SOURCE_hww2l2v}
+combineCards.py \
+  hwwof_0j_shape_7TeV=hwwof_0j_shape_7TeV.txt \
+  hwwof_1j_shape_7TeV=hwwof_1j_shape_7TeV.txt \
+  hwwof_2j_shape_7TeV=hwwof_2j_shape_7TeV.txt \
+  hwwof_0j_shape_8TeV=hwwof_0j_shape_8TeV.txt \
+  hwwof_1j_shape_8TeV=hwwof_1j_shape_8TeV.txt \
+  hwwof_2j_shape_8TeV=hwwof_2j_shape_8TeV.txt &> hww2l2v_in.txt
+cd -
+
+./bin/RoundTrip -i ${SOURCE_hww2l2v}/hww2l2v_in.txt -o ${WORKAREA}/hww2l2v_out.txt -r ${WORKAREA}/hww2l2v_out.root -m 125 --print &> ${WORKAREA}/hww2l2v.log
+
+text2workspace.py -b ${SOURCE_hww2l2v}/hww2l2v_in.txt -o ${WORKAREA}/ws_hww2l2v_in.root  --default-morphing shape2 -m 125
+text2workspace.py -b ${WORKAREA}/hww2l2v_out.txt -o ${WORKAREA}/ws_hww2l2v_out.root --default-morphing shape2 -m 125
+
+combine -M MaxLikelihoodFit ${DEF_MLFIT} --out=${WORKAREA} -m 125 ${WORKAREA}/ws_hww2l2v_in.root
+mv ${WORKAREA}/mlfit.root ${WORKAREA}/mlfit_hww2l2v_in.root
+combine -M MaxLikelihoodFit ${DEF_MLFIT} --out=${WORKAREA} -m 125 ${WORKAREA}/ws_hww2l2v_out.root
+mv ${WORKAREA}/mlfit.root ${WORKAREA}/mlfit_hww2l2v_out.root
+
+./bin/PostFitShapes -d ${WORKAREA}/hww2l2v_out.txt -o ${WORKAREA}/shapes_hww2l2v_out.root -m 125 -f ${WORKAREA}/mlfit_hww2l2v_out.root:fit_s --postfit --sampling --print

--- a/CombineHarvester/CombineTools/src/CombineHarvester_Creation.cc
+++ b/CombineHarvester/CombineTools/src/CombineHarvester_Creation.cc
@@ -93,7 +93,8 @@ void CombineHarvester::ExtractShapes(std::string const& file,
   }
   if (syst_rule == "") return;
   for (unsigned  i = 0; i < systs_.size(); ++i) {
-    if (systs_[i]->type() != "shape") continue;
+    if (systs_[i]->type() != "shape" && systs_[i]->type() != "shapeN2")
+      continue;
     LoadShapes(systs_[i].get(), mapping);
   }
 }

--- a/CombineHarvester/CombineTools/src/CombineHarvester_Datacards.cc
+++ b/CombineHarvester/CombineTools/src/CombineHarvester_Datacards.cc
@@ -365,7 +365,7 @@ void CombineHarvester::FillHistMappings(std::vector<HistMapping> & mappings) {
       });
     }
 
-    bool prototype_ok = true;
+    bool prototype_ok = false;
     HistMapping prototype;
     std::vector<HistMapping> full_list;
     auto pmap = ch_bin.GenerateProcSystMap();
@@ -406,6 +406,7 @@ void CombineHarvester::FillHistMappings(std::vector<HistMapping> & mappings) {
       }
 
       if (!prototype.pattern.size()) {
+        prototype_ok = true;
         prototype.process = "*";
         prototype.category = bin;
         prototype.pattern = obj_name;

--- a/CombineHarvester/CombineTools/src/CombineHarvester_Evaluate.cc
+++ b/CombineHarvester/CombineTools/src/CombineHarvester_Evaluate.cc
@@ -269,8 +269,10 @@ TH1F CombineHarvester::GetShapeInternal(ProcSystMap const& lookup,
       std::string var_name = "CMS_th1x";
       if (data_obj) var_name = data_obj->get()->first()->GetName();
       TH1::AddDirectory(false);
-      TH1F proc_shape = *(dynamic_cast<TH1F*>(
-          procs_[i]->pdf()->createHistogram(var_name.c_str())));
+      TH1F *tmp = dynamic_cast<TH1F*>(
+          procs_[i]->pdf()->createHistogram(var_name.c_str()));
+      TH1F proc_shape = *tmp;
+      delete tmp;
       if (!procs_[i]->pdf()->selfNormalized()) {
         // LOGLINE(log(), "Have a pdf that is not selfNormalized");
         // std::cout << "Integral: " << proc_shape.Integral() << "\n";
@@ -321,8 +323,10 @@ TH1F CombineHarvester::GetObservedShape() {
       proc_shape = obs_[i]->ShapeAsTH1F();
     } else if (obs_[i]->data()) {
       std::string var_name = obs_[i]->data()->get()->first()->GetName();
-      proc_shape = *(dynamic_cast<TH1F*>(obs_[i]->data()->createHistogram(
-                             var_name.c_str())));
+      TH1F *tmp = dynamic_cast<TH1F*>(obs_[i]->data()->createHistogram(
+                             var_name.c_str()));
+      proc_shape = *tmp;
+      delete tmp;
       proc_shape.Scale(1. / proc_shape.Integral());
     }
     proc_shape.Scale(p_rate);

--- a/CombineHarvester/CombineTools/src/Process.cc
+++ b/CombineHarvester/CombineTools/src/Process.cc
@@ -142,8 +142,10 @@ TH1F Process::ShapeAsTH1F() const {
     }
   } else if (this->data()) {
     std::string var_name = this->data()->get()->first()->GetName();
-    res = *(dynamic_cast<TH1F*>(this->data()->createHistogram(
-                           var_name.c_str())));
+    TH1F *tmp = dynamic_cast<TH1F*>(this->data()->createHistogram(
+                           var_name.c_str()));
+    res = *tmp;
+    delete tmp;
     if (res.Integral() > 0.) res.Scale(1. / res.Integral());
   }
   return res;

--- a/CombineHarvester/CombineTools/test/PostFitPlot2.cpp
+++ b/CombineHarvester/CombineTools/test/PostFitPlot2.cpp
@@ -31,7 +31,7 @@ using namespace std;
 //     } 
 // }
 
-int main(int argc, char* argv[]){
+int main(int /*argc*/, char* /*argv*/[]){
   /*
   string cfg;                                   // The configuration file
   string channel        = "";

--- a/CombineHarvester/CombineTools/test/PostFitShapes.cpp
+++ b/CombineHarvester/CombineTools/test/PostFitShapes.cpp
@@ -105,7 +105,8 @@ int main(int argc, char* argv[]){
   // for the postfit
   if (postfit) {
     res = new RooFitResult(ch::OpenFromTFile<RooFitResult>(fitresult));
-    cmb.UpdateParameters(ch::ExtractFitParameters(*res));
+    cmb.UpdateParameters(res);
+    // cmb.PrintAll();
 
     if (factors) {
       std::cout << boost::format("\n%-25s %-32s\n") % "Bin" % "Total relative uncert. (postfit)";

--- a/CombineHarvester/CombineTools/test/PostFitShapes.cpp
+++ b/CombineHarvester/CombineTools/test/PostFitShapes.cpp
@@ -61,6 +61,17 @@ int main(int argc, char* argv[]){
   ch::CombineHarvester cmb;
   cmb.ParseDatacard(datacard, "", "", "", 0, mass);
 
+  // Drop any process that has no hist/data/pdf
+  cmb.FilterProcs([&](ch::Process * proc) {
+    bool no_shape = !proc->shape() && !proc->data() && !proc->pdf();
+    if (no_shape) {
+      std::cout << "Filtering process with no shape:\n";
+      std::cout << ch::Process::PrintHeader;
+      std::cout << *proc << "\n";
+    }
+    return no_shape;
+  });
+
   RooFitResult *res = nullptr;
   auto bins = cmb.bin_set();
 

--- a/CombineHarvester/CombineTools/test/RoundTrip.cpp
+++ b/CombineHarvester/CombineTools/test/RoundTrip.cpp
@@ -49,6 +49,7 @@ int main(int argc, char* argv[]){
   po::notify(vm);
 
   ch::CombineHarvester cmb;
+  // cmb.SetVerbosity(2);
 
   cmb.ParseDatacard(datacard, "", "", "", 0, mass);
 


### PR DESCRIPTION
 - ch::Process and ch::Systamatic can now store RooDataHist pointers instead of TH1.
 - LoadShapes will preferentially add a RooAbsData instead of a RooAbsPdf to a ch::Process (if both can be found in the RooWorkspace)
 - Handling of HistMapping is also improved to allow for syst_patterns to refer to RooDataHist objects
 - Remove calculation of HistMappings from WriteDatacard and instead do this in a dedicated method. This new method (FillHistMappings) tries to be more clever with determining a common mapping for all processes in a given bin
 - Add a flag that allows for missing shapes when parsing/writing and evaluating
 - In Evalulate routines, allow for the fact that RooAbsPdf may not already be normalised
 - Also addresses #542 
 - add support for shapeN2 systematic type
 - started work on roundtrip validation