### PR TITLE
TGraph2D interpolation and code for applying xs*br to H->hh+A->Zh combination

### DIFF
--- a/data/Hhh-protocol.txt
+++ b/data/Hhh-protocol.txt
@@ -8,6 +8,8 @@ python HiggsAnalysis/HiggsToTauTau/scripts/doHTohh.py --update-all --config=Higg
 
 #The following command applies the correct XS*BR for each tanb point we are interested in for the model-dependent limits 
 lxb-xsec2tanb.py --ana-type="Hhh" --model="mhmodp" --customTanb="1,1.5,2,2.5,3" LIMITS-HTohh-mhmodp/*/*
+#To combine A->Zh and H->hh fo rmodel dependent limits, make a directory with A->Zh and H->hh datacards in the mass folders and both shape files in the common folder and run:
+lxb-xsec2tanb.py --ana-type"HhhAndAZh" --model="low-tb-high" --customTanb="1,1.5,2,2.5,3" LIMITS-HhhAndAZh/*/*
 
 #To set up model-dependent limits for the 2HD model we need a different directory structure :
 python HiggsAnalysis/HiggsToTauTau/scripts/doHTohh.py --update-all --config=HiggsAnalysis/HiggsToTauTau/data/limits.config-Hhh -a bbb --label="SomeLabel" --model=2HDM --new-merging --new-merging-threshold 0.5

--- a/interface/PlotLimits.h
+++ b/interface/PlotLimits.h
@@ -243,6 +243,8 @@ class PlotLimits {
   bool Brazilian_;
   /// use linear or TSpline3 fitting between calculated limit points (used for option tanb)
   bool linearFit_;
+  /// use TGraph2D interpolation or old method (used for option tanb)
+  bool graphInterpolate_;
   /// print constraint on mA-tanb plane from Higgs boson at 125 GeV? (used for option tanb)
   bool higgs125_;
   /// add ATLAS(htt) in MSSM mA-tanb plot

--- a/python/ModelParams_BASE.py
+++ b/python/ModelParams_BASE.py
@@ -164,7 +164,15 @@ class ModelParams_BASE:
         brname = {'tt':'BR-tautau', 'bb':'BR-bb', 'mm':'BR-mumu', 'HTohhTo2Tau2B':'BR-hh', 'AToZhToLLTauTau':'BR-Zh', 'AToZhToLLBB':'BR-Zh', 'AZh':'BR-Zh', 'tHpb':'BR-tHpb', 'taunu':'BR-taunu'}
         if decay[1:] not in brname:
             exit('ERROR: Decay channel \'%s\' not supported'%decay)
-        if self.ana_type=='Hhh' :
+        if self.ana_type=='HhhAndAZh' :
+            if channel == 'ggHTohhTo2Tau2B' :
+                if self.query_masses('H',query)<260 or self.query_masses('H',query)>350 :
+                    return str(0)
+                else :
+                    return str(query['higgses'][higgs][brname[channel[2:]]]*query['higgses']['h'][brname['bb']]*query['higgses']['h'][brname[decay[1:]]]*2) #factor 2: bbtautau or tautaubb
+            elif channel == 'AZh' :
+                return str(query['higgses'][higgs][brname[channel]]*query['higgses']['h'][brname['tt']]*0.06729) #BR(Z->ll)=0.03363(ee)+0.03366(mumu) (tautau is not considered)
+        elif self.ana_type=='Hhh' :
             if channel=='ggHTohhTo2Tau2B' :
                 return str(query['higgses'][higgs][brname[channel[2:]]]*query['higgses']['h'][brname['bb']]*query['higgses']['h'][brname[decay[1:]]]*2) #factor 2: bbtautau or tautaubb
             elif channel=='ggAToZhToLLBB' :

--- a/python/layouts/tanb-2HDMty2-azh.py
+++ b/python/layouts/tanb-2HDMty2-azh.py
@@ -4,18 +4,20 @@ layout = cms.PSet(
     ## dataset
     #dataset = cms.string("#scale[1.5]{CMS}   h,H,A#rightarrow#tau#tau                     19.7 fb^{-1} (8 TeV) + 4.9 fb^{-1} (7 TeV)"),
     #dataset = cms.string("#scale[1.5]{CMS} (unpublished), h,H,A#rightarrow#tau#tau, 19.7 fb^{-1} (8 TeV) + 4.9 fb^{-1} (7 TeV)"),
-    dataset = cms.string("#scale[1.5]{CMS} Preliminary,A#rightarrowZh#rightarrowll#tau#tau, 19.7 fb^{-1} (8 TeV)"),
+    #dataset = cms.string("#scale[1.5]{CMS} Preliminary, h,H,A#rightarrow#tau#tau, 19.7 fb^{-1} (8 TeV) + 4.9 fb^{-1} (7 TeV)"),
     #dataset = cms.string("#scale[1.5]{CMS}   h,H,A#rightarrow#tau#tau                                           18.3 fb^{-1} (8 TeV)"),
+    #dataset = cms.string("#scale[1.5]{CMS}   h,H,A#rightarrow#tau#tau                                           19.7 fb^{-1} (8 TeV)"),
+    dataset = cms.string("#scale[1.5]{CMS} Preliminary, A#rightarrowZh#rightarrowll#tau#tau,  19.7 fb^{-1} (8 TeV)"),
     ## x-axis title
-    xaxis = cms.string("m_{A} [GeV]"),
-    ## x-axis title
+    xaxis = cms.string("cos(#beta-#alpha)"),
+    ## y-axis title
     yaxis = cms.string("#bf{tan#beta}"),
     ## theory label 
-    theory = cms.string("MSSM low-tan#beta-high scenario"),
+    theory = cms.string("2HDM type-II"),
     ## min for plotting
-    min = cms.double(1.05),
+    min = cms.double(1),
     ## max for plotting
-    max = cms.double(4),
+    max = cms.double(10),
     ## min for plotting
     log = cms.int32(0),
     ## print to png
@@ -28,48 +30,46 @@ layout = cms.PSet(
     root = cms.bool(True),
     ## define verbosity level
     verbosity = cms.uint32(3),
-    ## Plotting A->Zh or combination? (don't draw mH excluded band)
-    azh=cms.bool(True),
-    ## define output label
-    outputLabel = cms.string("mA-tanb-cmb") ,
+    outputLabel = cms.string("cosba-tanb-azh") ,
     ## define masspoints for limit plot
     masspoints = cms.vdouble(
-    #160.
-   #,170.
-   #,180.
-   #,190.
-   #,200.
-   #,210.
-   220.
-   ,230.
-   ,240.
-   ,250.  
-   ,260.
-   ,270.
-   ,280.
-   ,290.
-   ,300.
-   ,310.
-   ,320.
-   ,330.
-   ,340.
-   ,350.
-      ),
+   -1
+   ,-0.9
+   ,-0.8
+   ,-0.7 
+   ,-0.6
+   ,-0.5
+   ,-0.4
+   ,-0.3
+   ,-0.2 
+   ,-0.1 
+   ,0 
+   ,0.1
+   ,0.2
+   ,0.3
+   ,0.4
+   ,0.5
+   ,0.6
+   ,0.7
+   ,0.8
+   ,0.9
+   ,1
+     ),
     ## is this mssm?
     mssm = cms.bool(True),
     ## is this MSSMvsSM?
     MSSMvsSM = cms.bool(False),
-    ## plot black and white friendly?
-    BlackWhite = cms.bool(False),
+    ## plot in Brazilian colors?
+    Brazilian = cms.bool(False),
     ## plot transparent?
     transparent = cms.bool(True),
     ## print the 2-sigma band
     outerband = cms.bool(True),
     ## plot expected only
     expectedOnly = cms.bool(True),
-    ## use linear fit rather than TSpline (only used if not using TGraph 2D interpolation)
+    ## use linear fit instead of TSpline for interpolation (if not using TGraph2D interpolation)
     linearFit = cms.bool(True),
-    ## use TGraph2D interpolation
+    ## use TGraph2D interpolation 
     graphInterpolate = cms.bool(True),
     ## print constraints from mH=125GeV
     higgs125 = cms.bool(True),

--- a/python/layouts/tanb-2HDMty2-cmb.py
+++ b/python/layouts/tanb-2HDMty2-cmb.py
@@ -4,18 +4,20 @@ layout = cms.PSet(
     ## dataset
     #dataset = cms.string("#scale[1.5]{CMS}   h,H,A#rightarrow#tau#tau                     19.7 fb^{-1} (8 TeV) + 4.9 fb^{-1} (7 TeV)"),
     #dataset = cms.string("#scale[1.5]{CMS} (unpublished), h,H,A#rightarrow#tau#tau, 19.7 fb^{-1} (8 TeV) + 4.9 fb^{-1} (7 TeV)"),
-    dataset = cms.string("#scale[1.5]{CMS} Preliminary,A#rightarrowZh#rightarrowll#tau#tau, 19.7 fb^{-1} (8 TeV)"),
+    #dataset = cms.string("#scale[1.5]{CMS} Preliminary, h,H,A#rightarrow#tau#tau, 19.7 fb^{-1} (8 TeV) + 4.9 fb^{-1} (7 TeV)"),
     #dataset = cms.string("#scale[1.5]{CMS}   h,H,A#rightarrow#tau#tau                                           18.3 fb^{-1} (8 TeV)"),
+    #dataset = cms.string("#scale[1.5]{CMS}   h,H,A#rightarrow#tau#tau                                           19.7 fb^{-1} (8 TeV)"),
+    dataset = cms.string("#scale[1.5]{CMS} Preliminary,H#rightarrowhh#rightarrow#tau#taubb + A#rightarrowZh#rightarrowll#tau#tau,  19.7 fb^{-1} (8 TeV)"),
     ## x-axis title
-    xaxis = cms.string("m_{A} [GeV]"),
-    ## x-axis title
+    xaxis = cms.string("cos(#beta-#alpha)"),
+    ## y-axis title
     yaxis = cms.string("#bf{tan#beta}"),
     ## theory label 
-    theory = cms.string("MSSM low-tan#beta-high scenario"),
+    theory = cms.string("2HDM type-II"),
     ## min for plotting
-    min = cms.double(1.05),
+    min = cms.double(1),
     ## max for plotting
-    max = cms.double(4),
+    max = cms.double(10),
     ## min for plotting
     log = cms.int32(0),
     ## print to png
@@ -28,48 +30,47 @@ layout = cms.PSet(
     root = cms.bool(True),
     ## define verbosity level
     verbosity = cms.uint32(3),
-    ## Plotting A->Zh or combination? (don't draw mH excluded band)
-    azh=cms.bool(True),
     ## define output label
-    outputLabel = cms.string("mA-tanb-cmb") ,
+    outputLabel = cms.string("cosba-tanb-cmb") ,
     ## define masspoints for limit plot
     masspoints = cms.vdouble(
-    #160.
-   #,170.
-   #,180.
-   #,190.
-   #,200.
-   #,210.
-   220.
-   ,230.
-   ,240.
-   ,250.  
-   ,260.
-   ,270.
-   ,280.
-   ,290.
-   ,300.
-   ,310.
-   ,320.
-   ,330.
-   ,340.
-   ,350.
-      ),
+   -1
+   ,-0.9
+   ,-0.8
+   ,-0.7 
+   ,-0.6
+   ,-0.5
+   ,-0.4
+   ,-0.3
+   ,-0.2 
+   ,-0.1 
+   ,0 
+   ,0.1
+   ,0.2
+   ,0.3
+   ,0.4
+   ,0.5
+   ,0.6
+   ,0.7
+   ,0.8
+   ,0.9
+   ,1
+     ),
     ## is this mssm?
     mssm = cms.bool(True),
     ## is this MSSMvsSM?
     MSSMvsSM = cms.bool(False),
-    ## plot black and white friendly?
-    BlackWhite = cms.bool(False),
+    ## plot in Brazilian colors?
+    Brazilian = cms.bool(False),
     ## plot transparent?
     transparent = cms.bool(True),
     ## print the 2-sigma band
     outerband = cms.bool(True),
     ## plot expected only
     expectedOnly = cms.bool(True),
-    ## use linear fit rather than TSpline (only used if not using TGraph 2D interpolation)
+    ## use linear fit instead of TSpline for interpolation (if not using TGraph2D interpolation)
     linearFit = cms.bool(True),
-    ## use TGraph2D interpolation
+    ## use TGraph2D interpolation 
     graphInterpolate = cms.bool(True),
     ## print constraints from mH=125GeV
     higgs125 = cms.bool(True),

--- a/python/layouts/tanb-2HDMty2-hhh.py
+++ b/python/layouts/tanb-2HDMty2-hhh.py
@@ -4,18 +4,20 @@ layout = cms.PSet(
     ## dataset
     #dataset = cms.string("#scale[1.5]{CMS}   h,H,A#rightarrow#tau#tau                     19.7 fb^{-1} (8 TeV) + 4.9 fb^{-1} (7 TeV)"),
     #dataset = cms.string("#scale[1.5]{CMS} (unpublished), h,H,A#rightarrow#tau#tau, 19.7 fb^{-1} (8 TeV) + 4.9 fb^{-1} (7 TeV)"),
-    dataset = cms.string("#scale[1.5]{CMS} Preliminary,A#rightarrowZh#rightarrowll#tau#tau, 19.7 fb^{-1} (8 TeV)"),
+    #dataset = cms.string("#scale[1.5]{CMS} Preliminary, h,H,A#rightarrow#tau#tau, 19.7 fb^{-1} (8 TeV) + 4.9 fb^{-1} (7 TeV)"),
     #dataset = cms.string("#scale[1.5]{CMS}   h,H,A#rightarrow#tau#tau                                           18.3 fb^{-1} (8 TeV)"),
+    #dataset = cms.string("#scale[1.5]{CMS}   h,H,A#rightarrow#tau#tau                                           19.7 fb^{-1} (8 TeV)"),
+    dataset = cms.string("#scale[1.5]{CMS} Preliminary, H#rightarrowhh#rightarrow#tau#taubb,  19.7 fb^{-1} (8 TeV)"),
     ## x-axis title
-    xaxis = cms.string("m_{A} [GeV]"),
-    ## x-axis title
+    xaxis = cms.string("cos(#beta-#alpha)"),
+    ## y-axis title
     yaxis = cms.string("#bf{tan#beta}"),
     ## theory label 
-    theory = cms.string("MSSM low-tan#beta-high scenario"),
+    theory = cms.string("2HDM type-II"),
     ## min for plotting
-    min = cms.double(1.05),
+    min = cms.double(1),
     ## max for plotting
-    max = cms.double(4),
+    max = cms.double(10),
     ## min for plotting
     log = cms.int32(0),
     ## print to png
@@ -28,48 +30,47 @@ layout = cms.PSet(
     root = cms.bool(True),
     ## define verbosity level
     verbosity = cms.uint32(3),
-    ## Plotting A->Zh or combination? (don't draw mH excluded band)
-    azh=cms.bool(True),
     ## define output label
-    outputLabel = cms.string("mA-tanb-cmb") ,
+    outputLabel = cms.string("cosba-tanb-hhh") ,
     ## define masspoints for limit plot
     masspoints = cms.vdouble(
-    #160.
-   #,170.
-   #,180.
-   #,190.
-   #,200.
-   #,210.
-   220.
-   ,230.
-   ,240.
-   ,250.  
-   ,260.
-   ,270.
-   ,280.
-   ,290.
-   ,300.
-   ,310.
-   ,320.
-   ,330.
-   ,340.
-   ,350.
-      ),
+   -1
+   ,-0.9
+   ,-0.8
+   ,-0.7 
+   ,-0.6
+   ,-0.5
+   ,-0.4
+   ,-0.3
+   ,-0.2 
+   ,-0.1 
+   ,0 
+   ,0.1
+   ,0.2
+   ,0.3
+   ,0.4
+   ,0.5
+   ,0.6
+   ,0.7
+   ,0.8
+   ,0.9
+   ,1
+     ),
     ## is this mssm?
     mssm = cms.bool(True),
     ## is this MSSMvsSM?
     MSSMvsSM = cms.bool(False),
-    ## plot black and white friendly?
-    BlackWhite = cms.bool(False),
+    ## plot in Brazilian colors?
+    Brazilian = cms.bool(False),
     ## plot transparent?
     transparent = cms.bool(True),
     ## print the 2-sigma band
     outerband = cms.bool(True),
     ## plot expected only
     expectedOnly = cms.bool(True),
-    ## use linear fit rather than TSpline (only used if not using TGraph 2D interpolation)
+    ## use linear fit instead of TSpline for interpolation (if not using TGraph2D interpolation)
     linearFit = cms.bool(True),
-    ## use TGraph2D interpolation
+    ## use TGraph2D interpolation 
     graphInterpolate = cms.bool(True),
     ## print constraints from mH=125GeV
     higgs125 = cms.bool(True),

--- a/python/layouts/tanb-lowtb-high-azh.py
+++ b/python/layouts/tanb-lowtb-high-azh.py
@@ -31,7 +31,7 @@ layout = cms.PSet(
     ## Plotting A->Zh or combination? (don't draw mH excluded band)
     azh=cms.bool(True),
     ## define output label
-    outputLabel = cms.string("mA-tanb-cmb") ,
+    outputLabel = cms.string("mA-tanb-azh") ,
     ## define masspoints for limit plot
     masspoints = cms.vdouble(
     #160.

--- a/python/layouts/tanb-lowtb-high-cmb.py
+++ b/python/layouts/tanb-lowtb-high-cmb.py
@@ -4,7 +4,7 @@ layout = cms.PSet(
     ## dataset
     #dataset = cms.string("#scale[1.5]{CMS}   h,H,A#rightarrow#tau#tau                     19.7 fb^{-1} (8 TeV) + 4.9 fb^{-1} (7 TeV)"),
     #dataset = cms.string("#scale[1.5]{CMS} (unpublished), h,H,A#rightarrow#tau#tau, 19.7 fb^{-1} (8 TeV) + 4.9 fb^{-1} (7 TeV)"),
-    dataset = cms.string("#scale[1.5]{CMS} Preliminary,A#rightarrowZh#rightarrowll#tau#tau, 19.7 fb^{-1} (8 TeV)"),
+    dataset = cms.string("#scale[1.5]{CMS} Preliminary,H#rightarrowhh#rightarrow#tau#taubb + A#rightarrowZh#rightarrowll#tau#tau, 19.7 fb^{-1} (8 TeV)"),
     #dataset = cms.string("#scale[1.5]{CMS}   h,H,A#rightarrow#tau#tau                                           18.3 fb^{-1} (8 TeV)"),
     ## x-axis title
     xaxis = cms.string("m_{A} [GeV]"),

--- a/python/layouts/tanb-lowtb-high-hhh.py
+++ b/python/layouts/tanb-lowtb-high-hhh.py
@@ -4,7 +4,7 @@ layout = cms.PSet(
     ## dataset
     #dataset = cms.string("#scale[1.5]{CMS}   h,H,A#rightarrow#tau#tau                     19.7 fb^{-1} (8 TeV) + 4.9 fb^{-1} (7 TeV)"),
     #dataset = cms.string("#scale[1.5]{CMS} (unpublished), h,H,A#rightarrow#tau#tau, 19.7 fb^{-1} (8 TeV) + 4.9 fb^{-1} (7 TeV)"),
-    dataset = cms.string("#scale[1.5]{CMS} Preliminary, H#rightarrowhh#rightarrowbb#tau#tau, 19.7 fb^{-1} (8 TeV)"),
+    dataset = cms.string("#scale[1.5]{CMS} Preliminary,H#rightarrowhh#rightarrow#tau#taubb, 19.7 fb^{-1} (8 TeV)"),
     #dataset = cms.string("#scale[1.5]{CMS}   h,H,A#rightarrow#tau#tau                                           18.3 fb^{-1} (8 TeV)"),
     ## x-axis title
     xaxis = cms.string("m_{A} [GeV]"),
@@ -28,8 +28,10 @@ layout = cms.PSet(
     root = cms.bool(True),
     ## define verbosity level
     verbosity = cms.uint32(3),
+    ## Plotting A->Zh or combination? (don't draw mH excluded band)
+    azh=cms.bool(False),
     ## define output label
-    outputLabel = cms.string("mA-tanb") ,
+    outputLabel = cms.string("mA-tanb-hhh") ,
     ## define masspoints for limit plot
     masspoints = cms.vdouble(
     160.
@@ -65,8 +67,11 @@ layout = cms.PSet(
     outerband = cms.bool(True),
     ## plot expected only
     expectedOnly = cms.bool(True),
-    ## print constraints from mH=125GeV
+    ## use linear fit rather than TSpline (only used if not using TGraph 2D interpolation)
     linearFit = cms.bool(True),
+    ## use TGraph2D interpolation
+    graphInterpolate = cms.bool(True),
+    ## print constraints from mH=125GeV
     higgs125 = cms.bool(True),
     ## add arXiv-1211-6956 (ATLAS) to plot
     arXiv_1211_6956 = cms.bool(False),

--- a/python/tools/mssm_xsec_tools.py
+++ b/python/tools/mssm_xsec_tools.py
@@ -290,7 +290,7 @@ class mssm_xsec_tools():
                 self._add_br_htt(parameter1, tan_beta, (higgs_type, output['higgses'][higgs_type]))
                 self._add_br_hmm(parameter1, tan_beta, (higgs_type, output['higgses'][higgs_type]))
                 self._add_br_hbb(parameter1, tan_beta, (higgs_type, output['higgses'][higgs_type]))
-                if ana_type=='Hhh' or ana_type=='AZh' :
+                if ana_type=='Hhh' or ana_type=='AZh' or ana_type=='HhhAndAZh' :
                     self._add_br_Hhh(parameter1, tan_beta, (higgs_type, output['higgses'][higgs_type]))
                     self._add_br_AZh(parameter1, tan_beta, (higgs_type, output['higgses'][higgs_type]))
                 self._add_mass(parameter1, tan_beta, (higgs_type, output['higgses'][higgs_type]))

--- a/src/MultidimFit.cc
+++ b/src/MultidimFit.cc
@@ -3,7 +3,7 @@
 /// This is the core plotting routine that can also be used within
 /// root macros. It is therefore not element of the PlotLimits class.
 void contour2D(TString xvar, int xbins, float xmin, float xmax, TString yvar, int ybins, float ymin, float ymax, float smx=1.0, float smy=1.0, TFile *fOut=0, TString name="contour2D");
-TList* contourFromTH2(TH2 *h2in, double threshold, int minPoints=20, bool require_minPoints=true);
+TList* contourFromTH2(TH2 *h2in, double threshold, int minPoints=20, bool require_minPoints=true,double multip=1.);
 void plottingScan2D(TCanvas& canv, TH2D* plot2D, TGraph* bestfit, TGraph* c68, TGraph* c95, TString file, TMarker* SMexpected, TMarker* SMexpectedLayer, std::string& xaxis, std::string& yaxis, std::string& masslabel, int mass, double xmin, double xmax, double ymin, double ymax, bool temp, bool log);
 
 void 

--- a/src/PlotLimits.cc
+++ b/src/PlotLimits.cc
@@ -1,5 +1,5 @@
 #include "HiggsAnalysis/HiggsToTauTau/interface/PlotLimits.h"
-TList* contourFromTH2(TH2 *h2in, double threshold, int minPoints=20, bool require_minPoints=true);
+TList* contourFromTH2(TH2 *h2in, double threshold, int minPoints=20, bool require_minPoints=true, double multip=1.);
 struct STestFunctor{
   STestFunctor() { sum = 0; }
   void operator() (TObject *aObj) {sum +=1;}
@@ -87,6 +87,7 @@ PlotLimits::PlotLimits(const char* output, const edm::ParameterSet& cfg) :
   HIG_12_052_      =cfg.existsAs<bool>("HIG_12_052"      ) ? cfg.getParameter<bool>("HIG_12_052"      ) : false;
   higgs125_ =cfg.existsAs<bool>("higgs125" ) ? cfg.getParameter<bool>("higgs125" ) : false;
   linearFit_=cfg.existsAs<bool>("linearFit") ? cfg.getParameter<bool>("linearFit") : false;
+  graphInterpolate_=cfg.existsAs<bool>("graphInterpolate") ? cfg.getParameter<bool>("graphInterpolate") : false;
   azh_ = cfg.existsAs<bool>("azh")? cfg.getParameter<bool>("azh") : false;
   transparent_=cfg.existsAs<bool>("transparent") ? cfg.getParameter<bool>("transparent") : false;
   expectedOnly_=cfg.existsAs<bool>("expectedOnly") ? cfg.getParameter<bool>("expectedOnly") : false;

--- a/src/Tanb.cc
+++ b/src/Tanb.cc
@@ -339,7 +339,6 @@ PlotLimits::plotTanb(TCanvas& canv, const char* directory, std::string HIG)
 
   int n_m2s, n_m1s, n_exp, n_p1s, n_p2s, n_obs;
   if(graphInterpolate_){
-    std::cout<<"AAA"<<std::endl;
     TIter iterm2s((TList *)contourFromTH2(minus2sigma_th2d, 1.0, 20, false,5));
     STestFunctor m2s = std::for_each( iterm2s.Begin(), TIter::End(), STestFunctor() );
     n_m2s=m2s.sum; 

--- a/src/Tanb.cc
+++ b/src/Tanb.cc
@@ -13,484 +13,484 @@ TList* contourFromTH2(TH2 *h2in, double threshold, int minPoints=20, bool requir
 void CLsControlPlots(TGraph* graph_minus2sigma, TGraph* graph_minus1sigma, TGraph* graph_expected, TGraph* graph_plus1sigma, TGraph* graph_plus2sigma, TGraph* graph_observed, const char* directory, float mass, int max, int ymax, const char* model);
 
 struct STestFunctor{
-	STestFunctor() { sum = 0; }
-	void operator() (TObject *aObj) {sum +=1;}
-	int sum;
+  STestFunctor() { sum = 0; }
+  void operator() (TObject *aObj) {sum +=1;}
+  int sum;
 } stestfunctor;
 
 struct myclass {
-	bool operator() (int i,int j) { return (i<j);}
+  bool operator() (int i,int j) { return (i<j);}
 } myobject;
 
-	void
+  void
 PlotLimits::plotTanb(TCanvas& canv, const char* directory, std::string HIG)
 {
-	//separate between MSSMvsSM and MSSMvsBG
-	double exclusion_=0;
-	if(MSSMvsSM_) exclusion_=0.05;
-	else exclusion_=1;
-	//different MSSM scenarios
-	std::string extralabel_ = "";
-	const char* model;
-	double tanbHigh=0, tanbLow=0, tanbLowHigh=0;
-	tanbHigh=tanbLow+tanbLowHigh;
-	if(theory_=="MSSM m_{h}^{max} scenario") {extralabel_= "mhmax-"; model = "mhmax-mu+200"; tanbHigh=60; tanbLow=0.5; tanbLowHigh=2;}
-	if(theory_=="MSSM m_{h}^{mod-} scenario") {extralabel_= "mhmodm-"; model = "mhmodm"; tanbHigh=60; tanbLow=0.5; tanbLowHigh=2;}
-	if(theory_=="MSSM m_{h}^{mod+} scenario") {extralabel_= "mhmodp-"; model = "mhmodp"; tanbHigh=60; tanbLow=0.5; tanbLowHigh=2;}
-	if(theory_=="MSSM low-m_{H} scenario") {extralabel_= "lowmH-"; model = "lowmH"; tanbHigh=9.5; tanbLow=1.5; tanbLowHigh=2;}
-	if(theory_=="MSSM light-stau scenario") {extralabel_= "lightstau1-"; model = "lightstau1"; tanbHigh=60; tanbLow=0.5; tanbLowHigh=3;}
-	if(theory_=="MSSM #scale[1.3]{#bf{#tau}}-phobic scenario") {extralabel_= "tauphobic-"; model = "tauphobic"; tanbHigh=50; tanbLow=1.0; tanbLowHigh=2;}
-	if(theory_=="MSSM light-stop scenario") {extralabel_= "lightstopmod-"; model = "lightstopmod"; tanbHigh=60; tanbLow=0.7; tanbLowHigh=2;}
-	if(theory_=="MSSM low-tan#beta-high scenario") {extralabel_= "low-tb-high-"; model = "low-tb-high"; tanbHigh=9.5; tanbLow=0.5; tanbLowHigh=2;}
-	if(theory_=="2HDM type-I") {extralabel_= "2HDMtyp1-"; model = "2HDMtyp1"; tanbHigh=10; tanbLow=1; tanbLowHigh=2;}
-	if(theory_=="2HDM type-II") {extralabel_= "2HDMtyp2-"; model = "2HDMtyp2"; tanbHigh=10; tanbLow=1; tanbLowHigh=2;}
+  //separate between MSSMvsSM and MSSMvsBG
+  double exclusion_=0;
+  if(MSSMvsSM_) exclusion_=0.05;
+  else exclusion_=1;
+  //different MSSM scenarios
+  std::string extralabel_ = "";
+  const char* model;
+  double tanbHigh=0, tanbLow=0, tanbLowHigh=0;
+  tanbHigh=tanbLow+tanbLowHigh;
+  if(theory_=="MSSM m_{h}^{max} scenario") {extralabel_= "mhmax-"; model = "mhmax-mu+200"; tanbHigh=60; tanbLow=0.5; tanbLowHigh=2;}
+  if(theory_=="MSSM m_{h}^{mod-} scenario") {extralabel_= "mhmodm-"; model = "mhmodm"; tanbHigh=60; tanbLow=0.5; tanbLowHigh=2;}
+  if(theory_=="MSSM m_{h}^{mod+} scenario") {extralabel_= "mhmodp-"; model = "mhmodp"; tanbHigh=60; tanbLow=0.5; tanbLowHigh=2;}
+  if(theory_=="MSSM low-m_{H} scenario") {extralabel_= "lowmH-"; model = "lowmH"; tanbHigh=9.5; tanbLow=1.5; tanbLowHigh=2;}
+  if(theory_=="MSSM light-stau scenario") {extralabel_= "lightstau1-"; model = "lightstau1"; tanbHigh=60; tanbLow=0.5; tanbLowHigh=3;}
+  if(theory_=="MSSM #scale[1.3]{#bf{#tau}}-phobic scenario") {extralabel_= "tauphobic-"; model = "tauphobic"; tanbHigh=50; tanbLow=1.0; tanbLowHigh=2;}
+  if(theory_=="MSSM light-stop scenario") {extralabel_= "lightstopmod-"; model = "lightstopmod"; tanbHigh=60; tanbLow=0.7; tanbLowHigh=2;}
+  if(theory_=="MSSM low-tan#beta-high scenario") {extralabel_= "low-tb-high-"; model = "low-tb-high"; tanbHigh=9.5; tanbLow=0.5; tanbLowHigh=2;}
+  if(theory_=="2HDM type-I") {extralabel_= "2HDMtyp1-"; model = "2HDMtyp1"; tanbHigh=10; tanbLow=1; tanbLowHigh=2;}
+  if(theory_=="2HDM type-II") {extralabel_= "2HDMtyp2-"; model = "2HDMtyp2"; tanbHigh=10; tanbLow=1; tanbLowHigh=2;}
 
-	// set up styles
-	SetStyle();
+  // set up styles
+  SetStyle();
 
-	//vectors of graphs from the tanb-CLs control plots used for tex/txt printing
-	std::vector<TGraph*> v_graph_minus2sigma;
-	std::vector<TGraph*> v_graph_minus1sigma;
-	std::vector<TGraph*> v_graph_expected;
-	std::vector<TGraph*> v_graph_plus1sigma;
-	std::vector<TGraph*> v_graph_plus2sigma;
-	std::vector<TGraph*> v_graph_observed;
-	float masses[50];
+  //vectors of graphs from the tanb-CLs control plots used for tex/txt printing
+  std::vector<TGraph*> v_graph_minus2sigma;
+  std::vector<TGraph*> v_graph_minus1sigma;
+  std::vector<TGraph*> v_graph_expected;
+  std::vector<TGraph*> v_graph_plus1sigma;
+  std::vector<TGraph*> v_graph_plus2sigma;
+  std::vector<TGraph*> v_graph_observed;
+  float masses[50];
 
-	int nxbins=0;
-	int array_number=0;
-	if(model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2")) array_number = (int)((bins_[bins_.size()-1]-bins_[0])/0.02)+1;
-	else array_number = (int)(bins_[bins_.size()-1]-bins_[0])/10+1; 
-	//else array_number = (int)bins_.size();
-	Double_t xbins[array_number];
+  int nxbins=0;
+  int array_number=0;
+  if(model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2")) array_number = (int)((bins_[bins_.size()-1]-bins_[0])/0.02)+1;
+  else array_number = (int)(bins_[bins_.size()-1]-bins_[0])/10+1; 
+  //else array_number = (int)bins_.size();
+  Double_t xbins[array_number];
 
-	if(model!=TString::Format("2HDMtyp1") && model!=TString::Format("2HDMtyp2")){
-		for(float mass=bins_[0]; mass<bins_[bins_.size()-1]+1; mass=mass+10){
-			xbins[nxbins]=mass;
-			nxbins++;;
-		}
-		xbins[nxbins]=bins_[bins_.size()-1]+1;
-	}
-	else {
-		for(double mass=bins_[0]; mass<bins_[bins_.size()-1]+0.01; mass=mass+0.02){
-			xbins[nxbins]=mass;
-			nxbins++;
-		}
-		xbins[nxbins]=bins_[bins_.size()-1]+0.01;
-	}
+  if(model!=TString::Format("2HDMtyp1") && model!=TString::Format("2HDMtyp2")){
+    for(float mass=bins_[0]; mass<bins_[bins_.size()-1]+1; mass=mass+10){
+      xbins[nxbins]=mass;
+      nxbins++;;
+    }
+    xbins[nxbins]=bins_[bins_.size()-1]+1;
+  }
+  else {
+    for(double mass=bins_[0]; mass<bins_[bins_.size()-1]+0.01; mass=mass+0.02){
+      xbins[nxbins]=mass;
+      nxbins++;
+    }
+    xbins[nxbins]=bins_[bins_.size()-1]+0.01;
+  }
 
-	TH2D *plane_minus2sigma = 0, *plane_minus1sigma = 0, *plane_expected = 0, *plane_plus1sigma = 0, *plane_plus2sigma = 0, *plane_observed = 0;
+  TH2D *plane_minus2sigma = 0, *plane_minus1sigma = 0, *plane_expected = 0, *plane_plus1sigma = 0, *plane_plus2sigma = 0, *plane_observed = 0;
 
-	if(model!=TString::Format("lowmH")) {
-		plane_minus2sigma = new TH2D("minus2sigma","minus2sigma", nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-		plane_minus1sigma = new TH2D("minus1sigma","minus1sigma", nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-		plane_expected    = new TH2D("expected","expected",       nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-		plane_plus1sigma  = new TH2D("plus1sigma","plus1sigma",   nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-		plane_plus2sigma  = new TH2D("plus2sigma","plus2sigma",   nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-		plane_observed    = new TH2D("observed","observed",       nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-	}
-	else { 
-		plane_minus2sigma = new TH2D("minus2sigma","minus2sigma", 29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-		plane_minus1sigma = new TH2D("minus1sigma","minus1sigma", 29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-		plane_expected    = new TH2D("expected",   "expected",    29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-		plane_plus1sigma  = new TH2D("plus1sigma","plus1sigma",   29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-		plane_plus2sigma  = new TH2D("plus2sigma","plus2sigma",   29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-		plane_observed    = new TH2D("observed","observed",       29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-	}
-
-
-	for(int idx=1; idx<plane_minus2sigma->GetNbinsX()+1; idx++){
-		for(int idy=1; idy<plane_minus2sigma->GetNbinsY()+1; idy++){
-			plane_minus2sigma->SetBinContent(idx, idy, 1.1);
-			plane_minus1sigma->SetBinContent(idx, idy, 1.1);
-			plane_expected   ->SetBinContent(idx, idy, 1.1);
-			plane_plus1sigma ->SetBinContent(idx, idy, 1.1);
-			plane_plus2sigma ->SetBinContent(idx, idy, 1.1);
-			plane_observed   ->SetBinContent(idx, idy, 1.1);
-		}
-	}
-
-	TGraph2D* graph_minus2sigma_2d = new TGraph2D();
-	TGraph2D* graph_minus1sigma_2d = new TGraph2D();
-	TGraph2D* graph_expected_2d = new TGraph2D();
-	TGraph2D* graph_plus1sigma_2d = new TGraph2D();
-	TGraph2D* graph_plus2sigma_2d = new TGraph2D();
-	TGraph2D* graph_observed_2d = new TGraph2D();
-	graph_minus2sigma_2d->SetTitle("");
-	graph_minus1sigma_2d->SetTitle("");
-	graph_expected_2d->SetTitle("");
-	graph_plus1sigma_2d->SetTitle("");
-	graph_plus2sigma_2d->SetTitle("");
-	graph_observed_2d->SetTitle("");
-
-	TH2D *minus2sigma_th2d =new TH2D("minus2sigma_th2d","minus2sigma_th2d",4*nxbins,xbins[0],xbins[nxbins-1],(int)((tanbHigh-tanbLow)*10-1),tanbLow,tanbHigh);
-	TH2D *minus1sigma_th2d =new TH2D("minus1sigma_th2d","minus1sigma_th2d",4*nxbins,xbins[0],xbins[nxbins-1],(int)((tanbHigh-tanbLow)*10-1),tanbLow,tanbHigh);
-	TH2D *expected_th2d =new TH2D("expected_th2d","expected_th2d",4*nxbins,xbins[0],xbins[nxbins-1],(int)((tanbHigh-tanbLow)*10-1),tanbLow,tanbHigh);
-	TH2D *plus1sigma_th2d =new TH2D("plus1sigma_th2d","plus1sigma_th2d",4*nxbins,xbins[0],xbins[nxbins-1],(int)((tanbHigh-tanbLow)*10-1),tanbLow,tanbHigh);
-	TH2D *plus2sigma_th2d =new TH2D("plus2sigma_th2d","plus2sigma_th2d",4*nxbins,xbins[0],xbins[nxbins-1],(int)((tanbHigh-tanbLow)*10-1),tanbLow,tanbHigh);
-	TH2D *observed_th2d =new TH2D("observed_th2d","observed_th2d",4*nxbins,xbins[0],xbins[nxbins-1],(int)((tanbHigh-tanbLow)*10-1),tanbLow,tanbHigh);
+  if(model!=TString::Format("lowmH")) {
+    plane_minus2sigma = new TH2D("minus2sigma","minus2sigma", nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+    plane_minus1sigma = new TH2D("minus1sigma","minus1sigma", nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+    plane_expected    = new TH2D("expected","expected",       nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+    plane_plus1sigma  = new TH2D("plus1sigma","plus1sigma",   nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+    plane_plus2sigma  = new TH2D("plus2sigma","plus2sigma",   nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+    plane_observed    = new TH2D("observed","observed",       nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+  }
+  else { 
+    plane_minus2sigma = new TH2D("minus2sigma","minus2sigma", 29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+    plane_minus1sigma = new TH2D("minus1sigma","minus1sigma", 29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+    plane_expected    = new TH2D("expected",   "expected",    29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+    plane_plus1sigma  = new TH2D("plus1sigma","plus1sigma",   29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+    plane_plus2sigma  = new TH2D("plus2sigma","plus2sigma",   29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+    plane_observed    = new TH2D("observed","observed",       29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+  }
 
 
+  for(int idx=1; idx<plane_minus2sigma->GetNbinsX()+1; idx++){
+    for(int idy=1; idy<plane_minus2sigma->GetNbinsY()+1; idy++){
+      plane_minus2sigma->SetBinContent(idx, idy, 1.1);
+      plane_minus1sigma->SetBinContent(idx, idy, 1.1);
+      plane_expected   ->SetBinContent(idx, idy, 1.1);
+      plane_plus1sigma ->SetBinContent(idx, idy, 1.1);
+      plane_plus2sigma ->SetBinContent(idx, idy, 1.1);
+      plane_observed   ->SetBinContent(idx, idy, 1.1);
+    }
+  }
 
-	if(HIG != ""){
-		std::cout << "NO LONGER SUPPORTED" << std::endl;
-	}
-	else{
-		//int ipoint_exp=0, ipoint_obs=0;
-		int kTwod=0;
+  TGraph2D* graph_minus2sigma_2d = new TGraph2D();
+  TGraph2D* graph_minus1sigma_2d = new TGraph2D();
+  TGraph2D* graph_expected_2d = new TGraph2D();
+  TGraph2D* graph_plus1sigma_2d = new TGraph2D();
+  TGraph2D* graph_plus2sigma_2d = new TGraph2D();
+  TGraph2D* graph_observed_2d = new TGraph2D();
+  graph_minus2sigma_2d->SetTitle("");
+  graph_minus1sigma_2d->SetTitle("");
+  graph_expected_2d->SetTitle("");
+  graph_plus1sigma_2d->SetTitle("");
+  graph_plus2sigma_2d->SetTitle("");
+  graph_observed_2d->SetTitle("");
 
-		for(unsigned int imass=0; imass<bins_.size(); ++imass){
-			// buffer mass value
-			float mass = bins_[imass];    
-			//control plots
-			TGraph* graph_minus2sigma = new TGraph();
-			TGraph* graph_minus1sigma = new TGraph();
-			TGraph* graph_expected = new TGraph();
-			TGraph* graph_plus1sigma = new TGraph();
-			TGraph* graph_plus2sigma = new TGraph();
-			TGraph* graph_observed = new TGraph();
+  TH2D *minus2sigma_th2d =new TH2D("minus2sigma_th2d","minus2sigma_th2d",4*nxbins,xbins[0],xbins[nxbins-1],(int)((tanbHigh-tanbLow)*10-1),tanbLow,tanbHigh);
+  TH2D *minus1sigma_th2d =new TH2D("minus1sigma_th2d","minus1sigma_th2d",4*nxbins,xbins[0],xbins[nxbins-1],(int)((tanbHigh-tanbLow)*10-1),tanbLow,tanbHigh);
+  TH2D *expected_th2d =new TH2D("expected_th2d","expected_th2d",4*nxbins,xbins[0],xbins[nxbins-1],(int)((tanbHigh-tanbLow)*10-1),tanbLow,tanbHigh);
+  TH2D *plus1sigma_th2d =new TH2D("plus1sigma_th2d","plus1sigma_th2d",4*nxbins,xbins[0],xbins[nxbins-1],(int)((tanbHigh-tanbLow)*10-1),tanbLow,tanbHigh);
+  TH2D *plus2sigma_th2d =new TH2D("plus2sigma_th2d","plus2sigma_th2d",4*nxbins,xbins[0],xbins[nxbins-1],(int)((tanbHigh-tanbLow)*10-1),tanbLow,tanbHigh);
+  TH2D *observed_th2d =new TH2D("observed_th2d","observed_th2d",4*nxbins,xbins[0],xbins[nxbins-1],(int)((tanbHigh-tanbLow)*10-1),tanbLow,tanbHigh);
 
-			TString fullpath = TString::Format("%s/%d/HypothesisTest.root", directory, (int)mass);
-			if (model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2")){ 
-				if(bins_[imass]!=(int)bins_[imass]) fullpath = TString::Format("%s/%0.1f/HypothesisTest.root", directory, bins_[imass]);
-				else fullpath = TString::Format("%s/%d/HypothesisTest.root",directory,(int)mass);
-			}
-			std::cout << "open file: " << fullpath << std::endl;
-			TFile* file_ = TFile::Open(fullpath); if(!file_){ std::cout << "--> TFile is corrupt: skipping masspoint." << std::endl; continue; }
-			TTree* limit = (TTree*) file_->Get("tree"); if(!limit){ std::cout << "--> TTree is corrupt: skipping masspoint." << std::endl; continue; }
-			double tanb, exp, obs, plus1sigma, minus1sigma, plus2sigma, minus2sigma;
-			limit->SetBranchAddress("tanb", &tanb );  
-			limit->SetBranchAddress("minus2sigma", &minus2sigma);
-			limit->SetBranchAddress("minus1sigma", &minus1sigma);
-			limit->SetBranchAddress("expected", &exp);
-			limit->SetBranchAddress("plus1sigma", &plus1sigma); 
-			limit->SetBranchAddress("plus2sigma", &plus2sigma);  
-			limit->SetBranchAddress("observed", &obs);  
-			int nevent = limit->GetEntries();   
-			//Drawing variable tanb with no graphics option.
-			//variable tanb stored in array fV1 (see TTree::Draw)
-			limit->Draw("tanb","","goff");
-			Int_t *index = new Int_t[nevent];
-			//sort array containing tanb in decreasing order
-			//The array index contains the entry numbers in increasing order in respect to tanb
-			TMath::Sort(nevent,limit->GetV1(),index,false); //changed from true (=default) =decreasing order
-			int k=0; double xmax=0; double ymax=0; //stuff needed for fitting;
-			// loop to find the crosspoint between low and high exclusion (tanbLowHigh)_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), plane_observed   ->GetYaxis()->FindBin(tanb), obs/exclusion_);
-			for(int i=0; i<nevent; ++i){
-				limit->GetEntry(index[i]);
-				//filling control plots
-				graph_minus2sigma->SetPoint(k, tanb, minus2sigma/exclusion_);
-				graph_minus1sigma->SetPoint(k, tanb, minus1sigma/exclusion_);
-				graph_expected   ->SetPoint(k, tanb, exp/exclusion_);
-				graph_plus1sigma ->SetPoint(k, tanb, plus1sigma/exclusion_);
-				graph_plus2sigma ->SetPoint(k, tanb, plus2sigma/exclusion_);
-				graph_observed   ->SetPoint(k, tanb, obs/exclusion_);
-				k++;      
-				for(int j=0; j<graph_minus2sigma->GetN(); j++){ 
-					if(graph_minus2sigma->GetY()[j]>ymax && graph_minus2sigma->GetX()[j]>=1) {ymax=graph_minus2sigma->GetY()[j]; xmax=graph_minus2sigma->GetX()[j]; tanbLowHigh=xmax;} //tanb>=1 hardcoded to fix that point 	  
-				}
 
-				// Fill TH2D with calculated limit points
-				plane_minus2sigma->SetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), plane_minus2sigma->GetYaxis()->FindBin(tanb), minus2sigma/exclusion_);
-				plane_minus1sigma->SetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), plane_minus1sigma->GetYaxis()->FindBin(tanb), minus1sigma/exclusion_);
-				plane_expected   ->SetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), plane_expected   ->GetYaxis()->FindBin(tanb), exp/exclusion_);
-				plane_plus1sigma ->SetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), plane_plus1sigma ->GetYaxis()->FindBin(tanb), plus1sigma/exclusion_);
-				plane_plus2sigma ->SetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), plane_plus2sigma ->GetYaxis()->FindBin(tanb), plus2sigma/exclusion_);
-				plane_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), plane_observed   ->GetYaxis()->FindBin(tanb), obs/exclusion_);
-				if(graphInterpolate_){
-					graph_minus2sigma_2d->SetPoint(kTwod,mass,tanb,minus2sigma/exclusion_);
-					graph_minus1sigma_2d->SetPoint(kTwod,mass,tanb,minus1sigma/exclusion_);
-					graph_expected_2d->SetPoint(kTwod,mass,tanb,exp/exclusion_);
-					graph_plus1sigma_2d->SetPoint(kTwod,mass,tanb,plus1sigma/exclusion_);
-					graph_plus2sigma_2d->SetPoint(kTwod,mass,tanb,plus2sigma/exclusion_);
-					graph_observed_2d->SetPoint(kTwod,mass,tanb,obs/exclusion_);
-					kTwod++;
-				}
-			}	
 
-			//control plot plotting
-			CLsControlPlots(graph_minus2sigma, graph_minus1sigma, graph_expected, graph_plus1sigma, graph_plus2sigma, graph_observed, directory, mass, xmax, ymax, model);
+  if(HIG != ""){
+    std::cout << "NO LONGER SUPPORTED" << std::endl;
+  }
+  else{
+    //int ipoint_exp=0, ipoint_obs=0;
+    int kTwod=0;
 
-			//push back graphs and save mass for tex/txt output printing
-			v_graph_minus2sigma.push_back(graph_minus2sigma);
-			v_graph_minus1sigma.push_back(graph_minus1sigma);
-			v_graph_expected.push_back(graph_expected);
-			v_graph_plus1sigma.push_back(graph_plus1sigma);
-			v_graph_plus2sigma.push_back(graph_plus2sigma);
-			v_graph_observed.push_back(graph_observed);
-			masses[imass]=mass;
+    for(unsigned int imass=0; imass<bins_.size(); ++imass){
+      // buffer mass value
+      float mass = bins_[imass];    
+      //control plots
+      TGraph* graph_minus2sigma = new TGraph();
+      TGraph* graph_minus1sigma = new TGraph();
+      TGraph* graph_expected = new TGraph();
+      TGraph* graph_plus1sigma = new TGraph();
+      TGraph* graph_plus2sigma = new TGraph();
+      TGraph* graph_observed = new TGraph();
 
-			// Interpolation along the y-axis for filling everything in between
-			limit->GetEntry(index[0]);
-			float tbmin=tanb; 
-			limit->GetEntry(index[nevent-1]);
-			float tbmax=tanb; 
-			for(int idy=1; idy<plane_minus2sigma->GetNbinsY()+1; idy++){
-				if (plane_minus2sigma->GetYaxis()->GetBinCenter(idy) > tbmin && plane_minus2sigma->GetYaxis()->GetBinCenter(idy) < tbmax ){
-					if(linearFit_){
-						plane_minus2sigma->SetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), idy, graph_minus2sigma->Eval(plane_minus2sigma->GetYaxis()->GetBinCenter(idy)));
-						plane_minus1sigma->SetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), idy, graph_minus1sigma->Eval(plane_minus1sigma->GetYaxis()->GetBinCenter(idy)));
-						plane_expected   ->SetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), idy, graph_expected   ->Eval(plane_expected   ->GetYaxis()->GetBinCenter(idy)));
-						plane_plus1sigma ->SetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), idy, graph_plus1sigma ->Eval(plane_plus1sigma ->GetYaxis()->GetBinCenter(idy)));
-						plane_plus2sigma ->SetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), idy, graph_plus2sigma ->Eval(plane_plus2sigma ->GetYaxis()->GetBinCenter(idy)));
-						plane_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), idy, graph_observed   ->Eval(plane_observed   ->GetYaxis()->GetBinCenter(idy)));
-					}
-					else{
-						plane_minus2sigma->SetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), idy, graph_minus2sigma->Eval(plane_minus2sigma->GetYaxis()->GetBinCenter(idy), 0, "S"));
-						plane_minus1sigma->SetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), idy, graph_minus1sigma->Eval(plane_minus1sigma->GetYaxis()->GetBinCenter(idy), 0, "S"));
-						plane_expected   ->SetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), idy, graph_expected   ->Eval(plane_expected   ->GetYaxis()->GetBinCenter(idy), 0, "S"));
-						plane_plus1sigma ->SetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), idy, graph_plus1sigma ->Eval(plane_plus1sigma ->GetYaxis()->GetBinCenter(idy), 0, "S"));
-						plane_plus2sigma ->SetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), idy, graph_plus2sigma ->Eval(plane_plus2sigma ->GetYaxis()->GetBinCenter(idy), 0, "S"));
-						plane_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), idy, graph_observed   ->Eval(plane_observed   ->GetYaxis()->GetBinCenter(idy), 0, "S"));
-					}
-				}
-				else if(plane_minus2sigma->GetYaxis()->GetBinCenter(idy) < tbmin){
-					plane_minus2sigma->SetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), idy, graph_minus2sigma->GetY()[0]);
-					plane_minus1sigma->SetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), idy, graph_minus1sigma->GetY()[0]);
-					plane_expected   ->SetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), idy, graph_expected   ->GetY()[0]);
-					plane_plus1sigma ->SetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), idy, graph_plus1sigma ->GetY()[0]);
-					plane_plus2sigma ->SetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), idy, graph_plus2sigma ->GetY()[0]);
-					plane_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), idy, graph_observed   ->GetY()[0]);
-				}
-				else if(plane_minus2sigma->GetYaxis()->GetBinCenter(idy) > tbmax){
-					plane_minus2sigma->SetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), idy, graph_minus2sigma->GetY()[graph_minus2sigma->GetN()-1]);
-					plane_minus1sigma->SetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), idy, graph_minus1sigma->GetY()[graph_minus1sigma->GetN()-1]);
-					plane_expected   ->SetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), idy, graph_expected   ->GetY()[graph_expected   ->GetN()-1]);
-					plane_plus1sigma ->SetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), idy, graph_plus1sigma ->GetY()[graph_plus1sigma ->GetN()-1]);
-					plane_plus2sigma ->SetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), idy, graph_plus2sigma ->GetY()[graph_plus2sigma ->GetN()-1]);
-					plane_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), idy, graph_observed   ->GetY()[graph_observed   ->GetN()-1]);
-				}
-			}
-		}
-	}	
-
-	// Interpolation along the x-axis for filling everything in between
-	for(int idy=0; idy<plane_minus2sigma->GetNbinsY()+1; idy++){
-		TGraph* graph_minus2sigma_tanb = new TGraph();
-		TGraph* graph_minus1sigma_tanb = new TGraph();
-		TGraph* graph_expected_tanb = new TGraph();
-		TGraph* graph_plus1sigma_tanb = new TGraph();
-		TGraph* graph_plus2sigma_tanb = new TGraph();
-		TGraph* graph_observed_tanb = new TGraph();
-		for(unsigned int imass=0; imass<bins_.size(); ++imass){
-			// buffer mass value
-			float mass = bins_[imass];
-			graph_minus2sigma_tanb->SetPoint(imass, mass, plane_minus2sigma->GetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), idy));
-			graph_minus1sigma_tanb->SetPoint(imass, mass, plane_minus1sigma->GetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), idy));
-			graph_expected_tanb   ->SetPoint(imass, mass, plane_expected   ->GetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), idy));
-			graph_plus1sigma_tanb ->SetPoint(imass, mass, plane_plus1sigma ->GetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), idy));
-			graph_plus2sigma_tanb ->SetPoint(imass, mass, plane_plus2sigma ->GetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), idy));
-			graph_observed_tanb   ->SetPoint(imass, mass, plane_observed   ->GetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), idy));
-		}
-		for(int idx=0; idx<plane_minus2sigma->GetNbinsX()+1; idx++)
-		{
-			if(linearFit_){
-				plane_minus2sigma->SetBinContent(idx, idy, graph_minus2sigma_tanb->Eval(plane_minus2sigma->GetXaxis()->GetBinCenter(idx)));
-				plane_minus1sigma->SetBinContent(idx, idy, graph_minus1sigma_tanb->Eval(plane_minus1sigma->GetXaxis()->GetBinCenter(idx)));
-				plane_expected   ->SetBinContent(idx, idy, graph_expected_tanb   ->Eval(plane_expected   ->GetXaxis()->GetBinCenter(idx)));
-				plane_plus1sigma ->SetBinContent(idx, idy, graph_plus1sigma_tanb ->Eval(plane_plus1sigma ->GetXaxis()->GetBinCenter(idx)));
-				plane_plus2sigma ->SetBinContent(idx, idy, graph_plus2sigma_tanb ->Eval(plane_plus2sigma ->GetXaxis()->GetBinCenter(idx)));
-				plane_observed   ->SetBinContent(idx, idy, graph_observed_tanb   ->Eval(plane_observed   ->GetXaxis()->GetBinCenter(idx)));
-			}
-			else{
-				plane_minus2sigma->SetBinContent(idx, idy, graph_minus2sigma_tanb->Eval(plane_minus2sigma->GetXaxis()->GetBinCenter(idx), 0, "S"));
-				plane_minus1sigma->SetBinContent(idx, idy, graph_minus1sigma_tanb->Eval(plane_minus1sigma->GetXaxis()->GetBinCenter(idx), 0, "S"));
-				plane_expected   ->SetBinContent(idx, idy, graph_expected_tanb   ->Eval(plane_expected   ->GetXaxis()->GetBinCenter(idx), 0, "S"));
-				plane_plus1sigma ->SetBinContent(idx, idy, graph_plus1sigma_tanb ->Eval(plane_plus1sigma ->GetXaxis()->GetBinCenter(idx), 0, "S"));
-				plane_plus2sigma ->SetBinContent(idx, idy, graph_plus2sigma_tanb ->Eval(plane_plus2sigma ->GetXaxis()->GetBinCenter(idx), 0, "S"));
-				plane_observed   ->SetBinContent(idx, idy, graph_observed_tanb   ->Eval(plane_observed   ->GetXaxis()->GetBinCenter(idx), 0, "S"));
-			}
-		}
+      TString fullpath = TString::Format("%s/%d/HypothesisTest.root", directory, (int)mass);
+      if (model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2")){ 
+	if(bins_[imass]!=(int)bins_[imass]) fullpath = TString::Format("%s/%0.1f/HypothesisTest.root", directory, bins_[imass]);
+	else fullpath = TString::Format("%s/%d/HypothesisTest.root",directory,(int)mass);
+      }
+      std::cout << "open file: " << fullpath << std::endl;
+      TFile* file_ = TFile::Open(fullpath); if(!file_){ std::cout << "--> TFile is corrupt: skipping masspoint." << std::endl; continue; }
+      TTree* limit = (TTree*) file_->Get("tree"); if(!limit){ std::cout << "--> TTree is corrupt: skipping masspoint." << std::endl; continue; }
+      double tanb, exp, obs, plus1sigma, minus1sigma, plus2sigma, minus2sigma;
+      limit->SetBranchAddress("tanb", &tanb );  
+      limit->SetBranchAddress("minus2sigma", &minus2sigma);
+      limit->SetBranchAddress("minus1sigma", &minus1sigma);
+      limit->SetBranchAddress("expected", &exp);
+      limit->SetBranchAddress("plus1sigma", &plus1sigma); 
+      limit->SetBranchAddress("plus2sigma", &plus2sigma);  
+      limit->SetBranchAddress("observed", &obs);  
+      int nevent = limit->GetEntries();   
+      //Drawing variable tanb with no graphics option.
+      //variable tanb stored in array fV1 (see TTree::Draw)
+      limit->Draw("tanb","","goff");
+      Int_t *index = new Int_t[nevent];
+      //sort array containing tanb in decreasing order
+      //The array index contains the entry numbers in increasing order in respect to tanb
+      TMath::Sort(nevent,limit->GetV1(),index,false); //changed from true (=default) =decreasing order
+      int k=0; double xmax=0; double ymax=0; //stuff needed for fitting;
+      // loop to find the crosspoint between low and high exclusion (tanbLowHigh)_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), plane_observed   ->GetYaxis()->FindBin(tanb), obs/exclusion_);
+      for(int i=0; i<nevent; ++i){
+	limit->GetEntry(index[i]);
+	//filling control plots
+	graph_minus2sigma->SetPoint(k, tanb, minus2sigma/exclusion_);
+	graph_minus1sigma->SetPoint(k, tanb, minus1sigma/exclusion_);
+	graph_expected   ->SetPoint(k, tanb, exp/exclusion_);
+	graph_plus1sigma ->SetPoint(k, tanb, plus1sigma/exclusion_);
+	graph_plus2sigma ->SetPoint(k, tanb, plus2sigma/exclusion_);
+	graph_observed   ->SetPoint(k, tanb, obs/exclusion_);
+	k++;      
+	for(int j=0; j<graph_minus2sigma->GetN(); j++){ 
+	  if(graph_minus2sigma->GetY()[j]>ymax && graph_minus2sigma->GetX()[j]>=1) {ymax=graph_minus2sigma->GetY()[j]; xmax=graph_minus2sigma->GetX()[j]; tanbLowHigh=xmax;} //tanb>=1 hardcoded to fix that point 	  
 	}
 
+	// Fill TH2D with calculated limit points
+	plane_minus2sigma->SetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), plane_minus2sigma->GetYaxis()->FindBin(tanb), minus2sigma/exclusion_);
+	plane_minus1sigma->SetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), plane_minus1sigma->GetYaxis()->FindBin(tanb), minus1sigma/exclusion_);
+	plane_expected   ->SetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), plane_expected   ->GetYaxis()->FindBin(tanb), exp/exclusion_);
+	plane_plus1sigma ->SetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), plane_plus1sigma ->GetYaxis()->FindBin(tanb), plus1sigma/exclusion_);
+	plane_plus2sigma ->SetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), plane_plus2sigma ->GetYaxis()->FindBin(tanb), plus2sigma/exclusion_);
+	plane_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), plane_observed   ->GetYaxis()->FindBin(tanb), obs/exclusion_);
 	if(graphInterpolate_){
-		for(int i=0; i<expected_th2d->GetXaxis()->GetNbins();i++){
-			for(int j=0; j<expected_th2d->GetYaxis()->GetNbins();j++){
-				minus2sigma_th2d->SetBinContent(i,j,graph_minus2sigma_2d->Interpolate(minus2sigma_th2d->GetXaxis()->GetBinCenter(i),minus2sigma_th2d->GetYaxis()->GetBinCenter(j)));
-				minus1sigma_th2d->SetBinContent(i,j,graph_minus1sigma_2d->Interpolate(minus1sigma_th2d->GetXaxis()->GetBinCenter(i),minus1sigma_th2d->GetYaxis()->GetBinCenter(j)));
-				expected_th2d->SetBinContent(i,j,graph_expected_2d->Interpolate(expected_th2d->GetXaxis()->GetBinCenter(i),expected_th2d->GetYaxis()->GetBinCenter(j)));
-				plus1sigma_th2d->SetBinContent(i,j,graph_plus1sigma_2d->Interpolate(plus1sigma_th2d->GetXaxis()->GetBinCenter(i),plus1sigma_th2d->GetYaxis()->GetBinCenter(j)));
-				plus2sigma_th2d->SetBinContent(i,j,graph_plus2sigma_2d->Interpolate(plus2sigma_th2d->GetXaxis()->GetBinCenter(i),plus2sigma_th2d->GetYaxis()->GetBinCenter(j)));
-				observed_th2d->SetBinContent(i,j,graph_observed_2d->Interpolate(observed_th2d->GetXaxis()->GetBinCenter(i),observed_th2d->GetYaxis()->GetBinCenter(j)));
-			}
-
-		}
-
+	  graph_minus2sigma_2d->SetPoint(kTwod,mass,tanb,minus2sigma/exclusion_);
+	  graph_minus1sigma_2d->SetPoint(kTwod,mass,tanb,minus1sigma/exclusion_);
+	  graph_expected_2d->SetPoint(kTwod,mass,tanb,exp/exclusion_);
+	  graph_plus1sigma_2d->SetPoint(kTwod,mass,tanb,plus1sigma/exclusion_);
+	  graph_plus2sigma_2d->SetPoint(kTwod,mass,tanb,plus2sigma/exclusion_);
+	  graph_observed_2d->SetPoint(kTwod,mass,tanb,obs/exclusion_);
+	  kTwod++;
 	}
+      }	
 
-	//   plane_minus2sigma->Smooth(1, "k5b");
-	//   plane_minus1sigma->Smooth(1, "k5b");
-	//   plane_expected   ->Smooth(1, "k5b");
-	//   plane_plus1sigma ->Smooth(1, "k5b");
-	//   plane_plus2sigma ->Smooth(1, "k5b");
-	//   plane_observed   ->Smooth(11, "k5b")
+      //control plot plotting
+      CLsControlPlots(graph_minus2sigma, graph_minus1sigma, graph_expected, graph_plus1sigma, graph_plus2sigma, graph_observed, directory, mass, xmax, ymax, model);
 
-	// Grabbing contours
+      //push back graphs and save mass for tex/txt output printing
+      v_graph_minus2sigma.push_back(graph_minus2sigma);
+      v_graph_minus1sigma.push_back(graph_minus1sigma);
+      v_graph_expected.push_back(graph_expected);
+      v_graph_plus1sigma.push_back(graph_plus1sigma);
+      v_graph_plus2sigma.push_back(graph_plus2sigma);
+      v_graph_observed.push_back(graph_observed);
+      masses[imass]=mass;
 
-
-	std::vector<TGraph*> gr_minus2sigma;
-	std::vector<TGraph*> gr_minus1sigma;
-	std::vector<TGraph*> gr_expected;
-	std::vector<TGraph*> gr_plus1sigma;
-	std::vector<TGraph*> gr_plus2sigma;
-	std::vector<TGraph*> gr_observed;
-	std::vector<TGraph*> gr_injected;
-	gr_injected.push_back(0);
-
-	int n_m2s, n_m1s, n_exp, n_p1s, n_p2s, n_obs;
-	if(graphInterpolate_){
-		std::cout<<"AAA"<<std::endl;
-		TIter iterm2s((TList *)contourFromTH2(minus2sigma_th2d, 1.0, 20, false,5));
-		STestFunctor m2s = std::for_each( iterm2s.Begin(), TIter::End(), STestFunctor() );
-		n_m2s=m2s.sum; 
-		TIter iterm1s((TList *)contourFromTH2(minus1sigma_th2d, 1.0, 20, false,5));
-		STestFunctor m1s = std::for_each( iterm1s.Begin(), TIter::End(), STestFunctor() );
-		n_m1s=m1s.sum; 
-		TIter iterexp((TList *)contourFromTH2(expected_th2d, 1.0, 20, false,5));
-		STestFunctor exp = std::for_each( iterexp.Begin(), TIter::End(), STestFunctor() );
-		n_exp=exp.sum; 
-		TIter iterp1s((TList *)contourFromTH2(plus1sigma_th2d, 1.0, 20, false,5));
-		STestFunctor p1s = std::for_each( iterp1s.Begin(), TIter::End(), STestFunctor() );
-		n_p1s=p1s.sum; 
-		TIter iterp2s((TList *)contourFromTH2(plus2sigma_th2d, 1.0, 20, false,5));
-		STestFunctor p2s = std::for_each( iterp2s.Begin(), TIter::End(), STestFunctor() );
-		n_p2s=p2s.sum; 
-		TIter iterobs((TList *)contourFromTH2(observed_th2d, 1.0, 20, false,5));
-		STestFunctor obs = std::for_each( iterobs.Begin(), TIter::End(), STestFunctor() );
-		n_obs=obs.sum; 
-		for(int i=0; i<n_m2s; i++) {gr_minus2sigma.push_back((TGraph *)((TList *)contourFromTH2(minus2sigma_th2d, 1.0, 20, false,5))->At(i));}
-		for(int i=0; i<n_m1s; i++) {gr_minus1sigma.push_back((TGraph *)((TList *)contourFromTH2(minus1sigma_th2d, 1.0, 20, false,5))->At(i));}
-		for(int i=0; i<n_exp; i++) {gr_expected.push_back(   (TGraph *)((TList *)contourFromTH2(expected_th2d,    1.0, 20, false,5))->At(i));}
-		for(int i=0; i<n_p1s; i++) {gr_plus1sigma.push_back( (TGraph *)((TList *)contourFromTH2(plus1sigma_th2d,  1.0, 20, false,5))->At(i));}
-		for(int i=0; i<n_p2s; i++) {gr_plus2sigma.push_back( (TGraph *)((TList *)contourFromTH2(plus2sigma_th2d,  1.0, 20, false,5))->At(i));}
-		for(int i=0; i<n_obs; i++) {gr_observed.push_back(   (TGraph *)((TList *)contourFromTH2(observed_th2d,    1.0, 20, false,5))->At(i));}
-
+      // Interpolation along the y-axis for filling everything in between
+      limit->GetEntry(index[0]);
+      float tbmin=tanb; 
+      limit->GetEntry(index[nevent-1]);
+      float tbmax=tanb; 
+      for(int idy=1; idy<plane_minus2sigma->GetNbinsY()+1; idy++){
+	if (plane_minus2sigma->GetYaxis()->GetBinCenter(idy) > tbmin && plane_minus2sigma->GetYaxis()->GetBinCenter(idy) < tbmax ){
+	  if(linearFit_){
+	    plane_minus2sigma->SetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), idy, graph_minus2sigma->Eval(plane_minus2sigma->GetYaxis()->GetBinCenter(idy)));
+	    plane_minus1sigma->SetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), idy, graph_minus1sigma->Eval(plane_minus1sigma->GetYaxis()->GetBinCenter(idy)));
+	    plane_expected   ->SetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), idy, graph_expected   ->Eval(plane_expected   ->GetYaxis()->GetBinCenter(idy)));
+	    plane_plus1sigma ->SetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), idy, graph_plus1sigma ->Eval(plane_plus1sigma ->GetYaxis()->GetBinCenter(idy)));
+	    plane_plus2sigma ->SetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), idy, graph_plus2sigma ->Eval(plane_plus2sigma ->GetYaxis()->GetBinCenter(idy)));
+	    plane_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), idy, graph_observed   ->Eval(plane_observed   ->GetYaxis()->GetBinCenter(idy)));
+	  }
+	  else{
+	    plane_minus2sigma->SetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), idy, graph_minus2sigma->Eval(plane_minus2sigma->GetYaxis()->GetBinCenter(idy), 0, "S"));
+	    plane_minus1sigma->SetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), idy, graph_minus1sigma->Eval(plane_minus1sigma->GetYaxis()->GetBinCenter(idy), 0, "S"));
+	    plane_expected   ->SetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), idy, graph_expected   ->Eval(plane_expected   ->GetYaxis()->GetBinCenter(idy), 0, "S"));
+	    plane_plus1sigma ->SetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), idy, graph_plus1sigma ->Eval(plane_plus1sigma ->GetYaxis()->GetBinCenter(idy), 0, "S"));
+	    plane_plus2sigma ->SetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), idy, graph_plus2sigma ->Eval(plane_plus2sigma ->GetYaxis()->GetBinCenter(idy), 0, "S"));
+	    plane_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), idy, graph_observed   ->Eval(plane_observed   ->GetYaxis()->GetBinCenter(idy), 0, "S"));
+	  }
 	}
-	else{
-		TIter iterm2s((TList *)contourFromTH2(plane_minus2sigma, 1.0, 20, false,1));
-		STestFunctor m2s = std::for_each( iterm2s.Begin(), TIter::End(), STestFunctor() );
-		n_m2s=m2s.sum; 
-		TIter iterm1s((TList *)contourFromTH2(plane_minus1sigma, 1.0, 20, false,1));
-		STestFunctor m1s = std::for_each( iterm1s.Begin(), TIter::End(), STestFunctor() );
-		n_m1s=m1s.sum; 
-		TIter iterexp((TList *)contourFromTH2(plane_expected, 1.0, 20, false,1));
-		STestFunctor exp = std::for_each( iterexp.Begin(), TIter::End(), STestFunctor() );
-		n_exp=exp.sum; 
-		TIter iterp1s((TList *)contourFromTH2(plane_plus1sigma, 1.0, 20, false,1));
-		STestFunctor p1s = std::for_each( iterp1s.Begin(), TIter::End(), STestFunctor() );
-		n_p1s=p1s.sum; 
-		TIter iterp2s((TList *)contourFromTH2(plane_plus2sigma, 1.0, 20, false,1));
-		STestFunctor p2s = std::for_each( iterp2s.Begin(), TIter::End(), STestFunctor() );
-		n_p2s=p2s.sum; 
-		TIter iterobs((TList *)contourFromTH2(plane_observed, 1.0, 20, false,1));
-		STestFunctor obs = std::for_each( iterobs.Begin(), TIter::End(), STestFunctor() );
-		n_obs=obs.sum; 
-		for(int i=0; i<n_m2s; i++) {gr_minus2sigma.push_back((TGraph *)((TList *)contourFromTH2(plane_minus2sigma, 1.0, 20, false,1))->At(i));}
-		for(int i=0; i<n_m1s; i++) {gr_minus1sigma.push_back((TGraph *)((TList *)contourFromTH2(plane_minus1sigma, 1.0, 20, false,1))->At(i));}
-		for(int i=0; i<n_exp; i++) {gr_expected.push_back(   (TGraph *)((TList *)contourFromTH2(plane_expected,    1.0, 20, false,1))->At(i));}
-		for(int i=0; i<n_p1s; i++) {gr_plus1sigma.push_back( (TGraph *)((TList *)contourFromTH2(plane_plus1sigma,  1.0, 20, false,1))->At(i));}
-		for(int i=0; i<n_p2s; i++) {gr_plus2sigma.push_back( (TGraph *)((TList *)contourFromTH2(plane_plus2sigma,  1.0, 20, false,1))->At(i));}
-		for(int i=0; i<n_obs; i++) {gr_observed.push_back(   (TGraph *)((TList *)contourFromTH2(plane_observed,    1.0, 20, false,1))->At(i));}
+	else if(plane_minus2sigma->GetYaxis()->GetBinCenter(idy) < tbmin){
+	  plane_minus2sigma->SetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), idy, graph_minus2sigma->GetY()[0]);
+	  plane_minus1sigma->SetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), idy, graph_minus1sigma->GetY()[0]);
+	  plane_expected   ->SetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), idy, graph_expected   ->GetY()[0]);
+	  plane_plus1sigma ->SetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), idy, graph_plus1sigma ->GetY()[0]);
+	  plane_plus2sigma ->SetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), idy, graph_plus2sigma ->GetY()[0]);
+	  plane_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), idy, graph_observed   ->GetY()[0]);
 	}
+	else if(plane_minus2sigma->GetYaxis()->GetBinCenter(idy) > tbmax){
+	  plane_minus2sigma->SetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), idy, graph_minus2sigma->GetY()[graph_minus2sigma->GetN()-1]);
+	  plane_minus1sigma->SetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), idy, graph_minus1sigma->GetY()[graph_minus1sigma->GetN()-1]);
+	  plane_expected   ->SetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), idy, graph_expected   ->GetY()[graph_expected   ->GetN()-1]);
+	  plane_plus1sigma ->SetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), idy, graph_plus1sigma ->GetY()[graph_plus1sigma ->GetN()-1]);
+	  plane_plus2sigma ->SetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), idy, graph_plus2sigma ->GetY()[graph_plus2sigma ->GetN()-1]);
+	  plane_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), idy, graph_observed   ->GetY()[graph_observed   ->GetN()-1]);
+	}
+      }
+    }
+  }	
 
-	//std::cout<< gr_minus2sigma.size() << " " << gr_minus1sigma.size() << " " << gr_expected.size() << " " << gr_plus1sigma.size() << " " << gr_plus2sigma.size() << " " << gr_observed.size() << std::endl;
+  // Interpolation along the x-axis for filling everything in between
+  for(int idy=0; idy<plane_minus2sigma->GetNbinsY()+1; idy++){
+    TGraph* graph_minus2sigma_tanb = new TGraph();
+    TGraph* graph_minus1sigma_tanb = new TGraph();
+    TGraph* graph_expected_tanb = new TGraph();
+    TGraph* graph_plus1sigma_tanb = new TGraph();
+    TGraph* graph_plus2sigma_tanb = new TGraph();
+    TGraph* graph_observed_tanb = new TGraph();
+    for(unsigned int imass=0; imass<bins_.size(); ++imass){
+      // buffer mass value
+      float mass = bins_[imass];
+      graph_minus2sigma_tanb->SetPoint(imass, mass, plane_minus2sigma->GetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), idy));
+      graph_minus1sigma_tanb->SetPoint(imass, mass, plane_minus1sigma->GetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), idy));
+      graph_expected_tanb   ->SetPoint(imass, mass, plane_expected   ->GetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), idy));
+      graph_plus1sigma_tanb ->SetPoint(imass, mass, plane_plus1sigma ->GetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), idy));
+      graph_plus2sigma_tanb ->SetPoint(imass, mass, plane_plus2sigma ->GetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), idy));
+      graph_observed_tanb   ->SetPoint(imass, mass, plane_observed   ->GetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), idy));
+    }
+    for(int idx=0; idx<plane_minus2sigma->GetNbinsX()+1; idx++)
+    {
+      if(linearFit_){
+	plane_minus2sigma->SetBinContent(idx, idy, graph_minus2sigma_tanb->Eval(plane_minus2sigma->GetXaxis()->GetBinCenter(idx)));
+	plane_minus1sigma->SetBinContent(idx, idy, graph_minus1sigma_tanb->Eval(plane_minus1sigma->GetXaxis()->GetBinCenter(idx)));
+	plane_expected   ->SetBinContent(idx, idy, graph_expected_tanb   ->Eval(plane_expected   ->GetXaxis()->GetBinCenter(idx)));
+	plane_plus1sigma ->SetBinContent(idx, idy, graph_plus1sigma_tanb ->Eval(plane_plus1sigma ->GetXaxis()->GetBinCenter(idx)));
+	plane_plus2sigma ->SetBinContent(idx, idy, graph_plus2sigma_tanb ->Eval(plane_plus2sigma ->GetXaxis()->GetBinCenter(idx)));
+	plane_observed   ->SetBinContent(idx, idy, graph_observed_tanb   ->Eval(plane_observed   ->GetXaxis()->GetBinCenter(idx)));
+      }
+      else{
+	plane_minus2sigma->SetBinContent(idx, idy, graph_minus2sigma_tanb->Eval(plane_minus2sigma->GetXaxis()->GetBinCenter(idx), 0, "S"));
+	plane_minus1sigma->SetBinContent(idx, idy, graph_minus1sigma_tanb->Eval(plane_minus1sigma->GetXaxis()->GetBinCenter(idx), 0, "S"));
+	plane_expected   ->SetBinContent(idx, idy, graph_expected_tanb   ->Eval(plane_expected   ->GetXaxis()->GetBinCenter(idx), 0, "S"));
+	plane_plus1sigma ->SetBinContent(idx, idy, graph_plus1sigma_tanb ->Eval(plane_plus1sigma ->GetXaxis()->GetBinCenter(idx), 0, "S"));
+	plane_plus2sigma ->SetBinContent(idx, idy, graph_plus2sigma_tanb ->Eval(plane_plus2sigma ->GetXaxis()->GetBinCenter(idx), 0, "S"));
+	plane_observed   ->SetBinContent(idx, idy, graph_observed_tanb   ->Eval(plane_observed   ->GetXaxis()->GetBinCenter(idx), 0, "S"));
+      }
+    }
+  }
 
-	//gr_expected[1]->SaveAs("exp_graph.root");
-	// create plots for additional comparisons
-	std::map<std::string, TGraph*> comparisons; TGraph* comp=0;
-	if(arXiv_1211_6956_){ comp = new TGraph(), arXiv_1211_6956 (comp); comp->SetName("arXiv_1211_6956" ); comparisons[std::string("ATLAS H#rightarrow#tau#tau (4.8/fb)")] = comp;}
-	if(arXiv_1204_2760_){ comp = new TGraph(); arXiv_1204_2760 (comp); comp->SetName("arXiv_1204_2760" ); comparisons[std::string("ATLAS H^{+} (4.6/fb)")               ] = comp;}
-	if(arXiv_1302_2892_){ comp = new TGraph(); arXiv_1302_2892 (comp); comp->SetName("arXiv_1302_2892" ); comparisons[std::string("CMS #phi#rightarrowb#bar{b}")        ] = comp;}
-	if(arXiv_1205_5736_){ comp = new TGraph(); arXiv_1205_5736 (comp); comp->SetName("arXiv_1205_5736" ); comparisons[std::string("CMS H^{+} (2/fb)")                   ] = comp;}
-	if(HIG_12_052_     ){ comp = new TGraph(); HIG_12_052_lower(comp); comp->SetName("HIG_12_052_lower"); comparisons[std::string("CMS H^{+} (2-4.9/fb)")               ] = comp;}
-	if(HIG_12_052_     ){ comp = new TGraph(); HIG_12_052_upper(comp); comp->SetName("HIG_12_052_upper"); comparisons[std::string("EMPTY")                              ] = comp;}
+  if(graphInterpolate_){
+    for(int i=0; i<expected_th2d->GetXaxis()->GetNbins();i++){
+      for(int j=0; j<expected_th2d->GetYaxis()->GetNbins();j++){
+	minus2sigma_th2d->SetBinContent(i,j,graph_minus2sigma_2d->Interpolate(minus2sigma_th2d->GetXaxis()->GetBinCenter(i),minus2sigma_th2d->GetYaxis()->GetBinCenter(j)));
+	minus1sigma_th2d->SetBinContent(i,j,graph_minus1sigma_2d->Interpolate(minus1sigma_th2d->GetXaxis()->GetBinCenter(i),minus1sigma_th2d->GetYaxis()->GetBinCenter(j)));
+	expected_th2d->SetBinContent(i,j,graph_expected_2d->Interpolate(expected_th2d->GetXaxis()->GetBinCenter(i),expected_th2d->GetYaxis()->GetBinCenter(j)));
+	plus1sigma_th2d->SetBinContent(i,j,graph_plus1sigma_2d->Interpolate(plus1sigma_th2d->GetXaxis()->GetBinCenter(i),plus1sigma_th2d->GetYaxis()->GetBinCenter(j)));
+	plus2sigma_th2d->SetBinContent(i,j,graph_plus2sigma_2d->Interpolate(plus2sigma_th2d->GetXaxis()->GetBinCenter(i),plus2sigma_th2d->GetYaxis()->GetBinCenter(j)));
+	observed_th2d->SetBinContent(i,j,graph_observed_2d->Interpolate(observed_th2d->GetXaxis()->GetBinCenter(i),observed_th2d->GetYaxis()->GetBinCenter(j)));
+      }
 
-	// setup contratins from Higgs mass
-	std::map<double,TGraphAsymmErrors*> higgsBands;
-	std::map<double,std::vector<TGraph*>> higgsBandsContour;
-	if(higgs125_&&model!=TString::Format("low-tb-high")){
-		higgsBands[3] = higgsConstraint(plane_expected, 125., 3., model, "h");
-		//   higgsBands[2] = higgsConstraint(plane_expected, 125., 3., model, "h",false);
-		//   higgsBands[3] = higgsConstraint(plane_expected, 305., 45., model, "H",true);
-		//higgsBands[1] = higgsConstraint(plane_expected, 125., 1., model);
-		//for(unsigned int deltaM=0; deltaM<3; ++deltaM){
-		//  higgsBands[3-deltaM] = higgsConstraint(plane_expected, 125., 4-deltaM, model);
-		//}
-	}  
-	else if(higgs125_&&model==TString::Format("low-tb-high")){
-		std::vector<std::vector<TGraph*>> higgsBandVec = higgsConstraintLowTb(plane_expected,125.,3.,305.,45.,model);
-		if(!azh_){
-			for(unsigned int ii=0;ii<higgsBandVec.size();ii++){
-				higgsBandsContour[ii]=higgsBandVec.at(ii);
-			}
-		}
-		else if(azh_){
-			higgsBandsContour[0]=higgsBandVec.at(1);
-		}
-	}
+    }
+
+  }
+
+  //   plane_minus2sigma->Smooth(1, "k5b");
+  //   plane_minus1sigma->Smooth(1, "k5b");
+  //   plane_expected   ->Smooth(1, "k5b");
+  //   plane_plus1sigma ->Smooth(1, "k5b");
+  //   plane_plus2sigma ->Smooth(1, "k5b");
+  //   plane_observed   ->Smooth(11, "k5b")
+
+  // Grabbing contours
 
 
-	// do the plotting
-	plottingTanb(canv, plane_expected, gr_minus2sigma, gr_minus1sigma, gr_expected, gr_plus1sigma, gr_plus2sigma, gr_observed, gr_injected, higgsBands,higgsBandsContour, comparisons, xaxis_, yaxis_, theory_, min_, max_, log_, transparent_, expectedOnly_, MSSMvsSM_, HIG, Brazilian_,azh_); 
-	/// setup the CMS Preliminary
-	//CMSPrelim(dataset_.c_str(), "", 0.145, 0.835);
-	//TPaveText* cmsprel = new TPaveText(0.145, 0.835+0.06, 0.145+0.30, 0.835+0.16, "NDC");
-	TPaveText* cmsprel = new TPaveText(0.135, 0.835+0.06, 0.145+0.30, 0.835+0.16, "NDC"); // for "unpublished" in header
-	cmsprel->SetBorderSize(   0 );
-	cmsprel->SetFillStyle(    0 );
-	cmsprel->SetTextAlign(   12 );
-	cmsprel->SetTextSize ( 0.03 );
-	cmsprel->SetTextColor(    1 );
-	cmsprel->SetTextFont (   62 );
-	cmsprel->AddText(dataset_.c_str());
-	cmsprel->Draw();
+  std::vector<TGraph*> gr_minus2sigma;
+  std::vector<TGraph*> gr_minus1sigma;
+  std::vector<TGraph*> gr_expected;
+  std::vector<TGraph*> gr_plus1sigma;
+  std::vector<TGraph*> gr_plus2sigma;
+  std::vector<TGraph*> gr_observed;
+  std::vector<TGraph*> gr_injected;
+  gr_injected.push_back(0);
 
-	// write results to files
-	if(png_){
-		canv.Print(std::string(output_).append("_").append(extralabel_).append(label_).append(".png").c_str());
-	}
-	if(pdf_){
-		canv.Print(std::string(output_).append("_").append(extralabel_).append(label_).append(".pdf").c_str());
-		canv.Print(std::string(output_).append("_").append(extralabel_).append(label_).append(".eps").c_str());
-	}
-	// write txt and tex files
-	if(txt_){
-		print(std::string(output_).append("_").append(extralabel_).append(label_).c_str(), v_graph_minus2sigma, v_graph_minus1sigma, v_graph_expected, v_graph_plus1sigma, v_graph_plus2sigma, v_graph_observed, tanbLow, tanbHigh, masses, "txt");
-		print(std::string(output_).append("_").append(extralabel_).append(label_).c_str(), v_graph_minus2sigma, v_graph_minus1sigma, v_graph_expected, v_graph_plus1sigma, v_graph_plus2sigma, v_graph_observed, tanbLow, tanbHigh, masses, "tex");
-	}
-	if(root_){
-		TFile* output = new TFile(std::string(output_).append("_").append(extralabel_).append(label_).append(".root").c_str(), "update");
-		if(!output->cd(output_.c_str())){
-			output->mkdir(output_.c_str());
-			output->cd(output_.c_str());
-		}
-		plane_expected->Write("plane_expected"); 
-		for(unsigned int i=0; i<gr_observed.size(); i++){
-			gr_observed[i]   ->Write(TString::Format("gr_observed_%d", i)  ); 
-		}
-		for(unsigned int i=0; i<gr_expected.size(); i++){
-			gr_expected[i]   ->Write(TString::Format("gr_expected_%d", i)    );
-		}
-		for(unsigned int i=0; i<gr_minus2sigma.size(); i++){
-			gr_minus2sigma[i]->Write(TString::Format("gr_minus2sigma_%d", i)    );
-		}
-		for(unsigned int i=0; i<gr_minus1sigma.size(); i++){
-			gr_minus1sigma[i]->Write(TString::Format("gr_minus1sigma_%d", i)    ); 
-		}
-		for(unsigned int i=0; i<gr_plus1sigma.size(); i++){
-			gr_plus1sigma[i] ->Write(TString::Format("gr_plus1sigma_%d", i)     );
-		}
-		for(unsigned int i=0; i<gr_plus2sigma.size(); i++){
-			gr_plus2sigma[i] ->Write(TString::Format("gr_plus2sigma_%d", i)     );
-		}
-		output->Close();
-	}
-	// save exclusion in each mass directory - needed for smart scan!
-	for(unsigned int imass=0; imass<bins_.size(); ++imass){
-		//std::cout << TString::Format("%s/%d/exclusion", directory, (int)bins_[imass]) << std::endl;
-		print(TString::Format("%s/%d/exclusion", directory, (int)bins_[imass]), v_graph_minus2sigma, v_graph_minus1sigma, v_graph_expected, v_graph_plus1sigma, v_graph_plus2sigma, v_graph_observed, tanbLow, tanbHigh, masses, "dat");
-	}
-	return;
+  int n_m2s, n_m1s, n_exp, n_p1s, n_p2s, n_obs;
+  if(graphInterpolate_){
+    std::cout<<"AAA"<<std::endl;
+    TIter iterm2s((TList *)contourFromTH2(minus2sigma_th2d, 1.0, 20, false,5));
+    STestFunctor m2s = std::for_each( iterm2s.Begin(), TIter::End(), STestFunctor() );
+    n_m2s=m2s.sum; 
+    TIter iterm1s((TList *)contourFromTH2(minus1sigma_th2d, 1.0, 20, false,5));
+    STestFunctor m1s = std::for_each( iterm1s.Begin(), TIter::End(), STestFunctor() );
+    n_m1s=m1s.sum; 
+    TIter iterexp((TList *)contourFromTH2(expected_th2d, 1.0, 20, false,5));
+    STestFunctor exp = std::for_each( iterexp.Begin(), TIter::End(), STestFunctor() );
+    n_exp=exp.sum; 
+    TIter iterp1s((TList *)contourFromTH2(plus1sigma_th2d, 1.0, 20, false,5));
+    STestFunctor p1s = std::for_each( iterp1s.Begin(), TIter::End(), STestFunctor() );
+    n_p1s=p1s.sum; 
+    TIter iterp2s((TList *)contourFromTH2(plus2sigma_th2d, 1.0, 20, false,5));
+    STestFunctor p2s = std::for_each( iterp2s.Begin(), TIter::End(), STestFunctor() );
+    n_p2s=p2s.sum; 
+    TIter iterobs((TList *)contourFromTH2(observed_th2d, 1.0, 20, false,5));
+    STestFunctor obs = std::for_each( iterobs.Begin(), TIter::End(), STestFunctor() );
+    n_obs=obs.sum; 
+    for(int i=0; i<n_m2s; i++) {gr_minus2sigma.push_back((TGraph *)((TList *)contourFromTH2(minus2sigma_th2d, 1.0, 20, false,5))->At(i));}
+    for(int i=0; i<n_m1s; i++) {gr_minus1sigma.push_back((TGraph *)((TList *)contourFromTH2(minus1sigma_th2d, 1.0, 20, false,5))->At(i));}
+    for(int i=0; i<n_exp; i++) {gr_expected.push_back(   (TGraph *)((TList *)contourFromTH2(expected_th2d,    1.0, 20, false,5))->At(i));}
+    for(int i=0; i<n_p1s; i++) {gr_plus1sigma.push_back( (TGraph *)((TList *)contourFromTH2(plus1sigma_th2d,  1.0, 20, false,5))->At(i));}
+    for(int i=0; i<n_p2s; i++) {gr_plus2sigma.push_back( (TGraph *)((TList *)contourFromTH2(plus2sigma_th2d,  1.0, 20, false,5))->At(i));}
+    for(int i=0; i<n_obs; i++) {gr_observed.push_back(   (TGraph *)((TList *)contourFromTH2(observed_th2d,    1.0, 20, false,5))->At(i));}
+
+  }
+  else{
+    TIter iterm2s((TList *)contourFromTH2(plane_minus2sigma, 1.0, 20, false,1));
+    STestFunctor m2s = std::for_each( iterm2s.Begin(), TIter::End(), STestFunctor() );
+    n_m2s=m2s.sum; 
+    TIter iterm1s((TList *)contourFromTH2(plane_minus1sigma, 1.0, 20, false,1));
+    STestFunctor m1s = std::for_each( iterm1s.Begin(), TIter::End(), STestFunctor() );
+    n_m1s=m1s.sum; 
+    TIter iterexp((TList *)contourFromTH2(plane_expected, 1.0, 20, false,1));
+    STestFunctor exp = std::for_each( iterexp.Begin(), TIter::End(), STestFunctor() );
+    n_exp=exp.sum; 
+    TIter iterp1s((TList *)contourFromTH2(plane_plus1sigma, 1.0, 20, false,1));
+    STestFunctor p1s = std::for_each( iterp1s.Begin(), TIter::End(), STestFunctor() );
+    n_p1s=p1s.sum; 
+    TIter iterp2s((TList *)contourFromTH2(plane_plus2sigma, 1.0, 20, false,1));
+    STestFunctor p2s = std::for_each( iterp2s.Begin(), TIter::End(), STestFunctor() );
+    n_p2s=p2s.sum; 
+    TIter iterobs((TList *)contourFromTH2(plane_observed, 1.0, 20, false,1));
+    STestFunctor obs = std::for_each( iterobs.Begin(), TIter::End(), STestFunctor() );
+    n_obs=obs.sum; 
+    for(int i=0; i<n_m2s; i++) {gr_minus2sigma.push_back((TGraph *)((TList *)contourFromTH2(plane_minus2sigma, 1.0, 20, false,1))->At(i));}
+    for(int i=0; i<n_m1s; i++) {gr_minus1sigma.push_back((TGraph *)((TList *)contourFromTH2(plane_minus1sigma, 1.0, 20, false,1))->At(i));}
+    for(int i=0; i<n_exp; i++) {gr_expected.push_back(   (TGraph *)((TList *)contourFromTH2(plane_expected,    1.0, 20, false,1))->At(i));}
+    for(int i=0; i<n_p1s; i++) {gr_plus1sigma.push_back( (TGraph *)((TList *)contourFromTH2(plane_plus1sigma,  1.0, 20, false,1))->At(i));}
+    for(int i=0; i<n_p2s; i++) {gr_plus2sigma.push_back( (TGraph *)((TList *)contourFromTH2(plane_plus2sigma,  1.0, 20, false,1))->At(i));}
+    for(int i=0; i<n_obs; i++) {gr_observed.push_back(   (TGraph *)((TList *)contourFromTH2(plane_observed,    1.0, 20, false,1))->At(i));}
+  }
+
+  //std::cout<< gr_minus2sigma.size() << " " << gr_minus1sigma.size() << " " << gr_expected.size() << " " << gr_plus1sigma.size() << " " << gr_plus2sigma.size() << " " << gr_observed.size() << std::endl;
+
+  //gr_expected[1]->SaveAs("exp_graph.root");
+  // create plots for additional comparisons
+  std::map<std::string, TGraph*> comparisons; TGraph* comp=0;
+  if(arXiv_1211_6956_){ comp = new TGraph(), arXiv_1211_6956 (comp); comp->SetName("arXiv_1211_6956" ); comparisons[std::string("ATLAS H#rightarrow#tau#tau (4.8/fb)")] = comp;}
+  if(arXiv_1204_2760_){ comp = new TGraph(); arXiv_1204_2760 (comp); comp->SetName("arXiv_1204_2760" ); comparisons[std::string("ATLAS H^{+} (4.6/fb)")               ] = comp;}
+  if(arXiv_1302_2892_){ comp = new TGraph(); arXiv_1302_2892 (comp); comp->SetName("arXiv_1302_2892" ); comparisons[std::string("CMS #phi#rightarrowb#bar{b}")        ] = comp;}
+  if(arXiv_1205_5736_){ comp = new TGraph(); arXiv_1205_5736 (comp); comp->SetName("arXiv_1205_5736" ); comparisons[std::string("CMS H^{+} (2/fb)")                   ] = comp;}
+  if(HIG_12_052_     ){ comp = new TGraph(); HIG_12_052_lower(comp); comp->SetName("HIG_12_052_lower"); comparisons[std::string("CMS H^{+} (2-4.9/fb)")               ] = comp;}
+  if(HIG_12_052_     ){ comp = new TGraph(); HIG_12_052_upper(comp); comp->SetName("HIG_12_052_upper"); comparisons[std::string("EMPTY")                              ] = comp;}
+
+  // setup contratins from Higgs mass
+  std::map<double,TGraphAsymmErrors*> higgsBands;
+  std::map<double,std::vector<TGraph*>> higgsBandsContour;
+  if(higgs125_&&model!=TString::Format("low-tb-high")){
+    higgsBands[3] = higgsConstraint(plane_expected, 125., 3., model, "h");
+    //   higgsBands[2] = higgsConstraint(plane_expected, 125., 3., model, "h",false);
+    //   higgsBands[3] = higgsConstraint(plane_expected, 305., 45., model, "H",true);
+    //higgsBands[1] = higgsConstraint(plane_expected, 125., 1., model);
+    //for(unsigned int deltaM=0; deltaM<3; ++deltaM){
+    //  higgsBands[3-deltaM] = higgsConstraint(plane_expected, 125., 4-deltaM, model);
+    //}
+  }  
+  else if(higgs125_&&model==TString::Format("low-tb-high")){
+    std::vector<std::vector<TGraph*>> higgsBandVec = higgsConstraintLowTb(plane_expected,125.,3.,305.,45.,model);
+    if(!azh_){
+      for(unsigned int ii=0;ii<higgsBandVec.size();ii++){
+	higgsBandsContour[ii]=higgsBandVec.at(ii);
+      }
+    }
+    else if(azh_){
+      higgsBandsContour[0]=higgsBandVec.at(1);
+    }
+  }
+
+
+  // do the plotting
+  plottingTanb(canv, plane_expected, gr_minus2sigma, gr_minus1sigma, gr_expected, gr_plus1sigma, gr_plus2sigma, gr_observed, gr_injected, higgsBands,higgsBandsContour, comparisons, xaxis_, yaxis_, theory_, min_, max_, log_, transparent_, expectedOnly_, MSSMvsSM_, HIG, Brazilian_,azh_); 
+  /// setup the CMS Preliminary
+  //CMSPrelim(dataset_.c_str(), "", 0.145, 0.835);
+  //TPaveText* cmsprel = new TPaveText(0.145, 0.835+0.06, 0.145+0.30, 0.835+0.16, "NDC");
+  TPaveText* cmsprel = new TPaveText(0.135, 0.835+0.06, 0.145+0.30, 0.835+0.16, "NDC"); // for "unpublished" in header
+  cmsprel->SetBorderSize(   0 );
+  cmsprel->SetFillStyle(    0 );
+  cmsprel->SetTextAlign(   12 );
+  cmsprel->SetTextSize ( 0.03 );
+  cmsprel->SetTextColor(    1 );
+  cmsprel->SetTextFont (   62 );
+  cmsprel->AddText(dataset_.c_str());
+  cmsprel->Draw();
+
+  // write results to files
+  if(png_){
+    canv.Print(std::string(output_).append("_").append(extralabel_).append(label_).append(".png").c_str());
+  }
+  if(pdf_){
+    canv.Print(std::string(output_).append("_").append(extralabel_).append(label_).append(".pdf").c_str());
+    canv.Print(std::string(output_).append("_").append(extralabel_).append(label_).append(".eps").c_str());
+  }
+  // write txt and tex files
+  if(txt_){
+    print(std::string(output_).append("_").append(extralabel_).append(label_).c_str(), v_graph_minus2sigma, v_graph_minus1sigma, v_graph_expected, v_graph_plus1sigma, v_graph_plus2sigma, v_graph_observed, tanbLow, tanbHigh, masses, "txt");
+    print(std::string(output_).append("_").append(extralabel_).append(label_).c_str(), v_graph_minus2sigma, v_graph_minus1sigma, v_graph_expected, v_graph_plus1sigma, v_graph_plus2sigma, v_graph_observed, tanbLow, tanbHigh, masses, "tex");
+  }
+  if(root_){
+    TFile* output = new TFile(std::string(output_).append("_").append(extralabel_).append(label_).append(".root").c_str(), "update");
+    if(!output->cd(output_.c_str())){
+      output->mkdir(output_.c_str());
+      output->cd(output_.c_str());
+    }
+    plane_expected->Write("plane_expected"); 
+    for(unsigned int i=0; i<gr_observed.size(); i++){
+      gr_observed[i]   ->Write(TString::Format("gr_observed_%d", i)  ); 
+    }
+    for(unsigned int i=0; i<gr_expected.size(); i++){
+      gr_expected[i]   ->Write(TString::Format("gr_expected_%d", i)    );
+    }
+    for(unsigned int i=0; i<gr_minus2sigma.size(); i++){
+      gr_minus2sigma[i]->Write(TString::Format("gr_minus2sigma_%d", i)    );
+    }
+    for(unsigned int i=0; i<gr_minus1sigma.size(); i++){
+      gr_minus1sigma[i]->Write(TString::Format("gr_minus1sigma_%d", i)    ); 
+    }
+    for(unsigned int i=0; i<gr_plus1sigma.size(); i++){
+      gr_plus1sigma[i] ->Write(TString::Format("gr_plus1sigma_%d", i)     );
+    }
+    for(unsigned int i=0; i<gr_plus2sigma.size(); i++){
+      gr_plus2sigma[i] ->Write(TString::Format("gr_plus2sigma_%d", i)     );
+    }
+    output->Close();
+  }
+  // save exclusion in each mass directory - needed for smart scan!
+  for(unsigned int imass=0; imass<bins_.size(); ++imass){
+    //std::cout << TString::Format("%s/%d/exclusion", directory, (int)bins_[imass]) << std::endl;
+    print(TString::Format("%s/%d/exclusion", directory, (int)bins_[imass]), v_graph_minus2sigma, v_graph_minus1sigma, v_graph_expected, v_graph_plus1sigma, v_graph_plus2sigma, v_graph_observed, tanbLow, tanbHigh, masses, "dat");
+  }
+  return;
 }
 
 
@@ -498,169 +498,169 @@ PlotLimits::plotTanb(TCanvas& canv, const char* directory, std::string HIG)
 
 
 void CLsControlPlots(TGraph* graph_minus2sigma, TGraph* graph_minus1sigma, TGraph* graph_expected, TGraph* graph_plus1sigma, TGraph* graph_plus2sigma, TGraph* graph_observed, const char* directory, float mass, int xmax, int ymax, const char* model){
-	//control plots showing the CLs value over tanb for each mass
-	//minus2sigma
-	TCanvas* canv_minus2sigma = new TCanvas();
-	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_minus2sigma = new TCanvas(TString::Format("tanb-CLs_025_%0.1f", mass), "", 600, 600);
-	else canv_minus2sigma = new TCanvas(TString::Format("tanb-CLs_025_%d", (int)mass), "", 600, 600);
-	canv_minus2sigma->cd();
-	canv_minus2sigma->SetGridx(1);
-	canv_minus2sigma->SetGridy(1);
-	graph_minus2sigma->SetMaximum(10);
-	graph_minus2sigma->GetXaxis()->SetTitle("tan#beta");
-	graph_minus2sigma->GetXaxis()->SetLabelFont(62);
-	graph_minus2sigma->GetXaxis()->SetTitleFont(62);
-	graph_minus2sigma->GetXaxis()->SetTitleColor(1);
-	graph_minus2sigma->GetXaxis()->SetTitleOffset(1.05);
-	graph_minus2sigma->GetYaxis()->SetTitle("CL_{s}");
-	graph_minus2sigma->GetYaxis()->SetLabelFont(62);
-	graph_minus2sigma->GetYaxis()->SetTitleFont(62);
-	graph_minus2sigma->GetYaxis()->SetTitleOffset(1.05);
-	graph_minus2sigma->GetYaxis()->SetLabelSize(0.03);
-	graph_minus2sigma->SetMarkerStyle(20);
-	graph_minus2sigma->SetMarkerSize(1.3);
-	ymax=0; ymax=0;
-	for(int j=0; j<graph_minus2sigma->GetN(); j++){ 
-		if(graph_minus2sigma->GetY()[j]>ymax) {ymax=graph_minus2sigma->GetY()[j]; xmax=graph_minus2sigma->GetX()[j];}
-	}
-	graph_minus2sigma->Draw("AP");
-	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_minus2sigma->Print(TString::Format("%s/%0.1f/tanb-CLs_025_%0.1f.png", directory, mass, mass));
-	else canv_minus2sigma->Print(TString::Format("%s/%d/tanb-CLs_025_%d.png", directory, (int)mass, (int)mass));
-	//minus1sigma
-	TCanvas* canv_minus1sigma = new TCanvas();
-	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_minus1sigma = new TCanvas(TString::Format("tanb-CLs_160_%0.1f", mass), "", 600, 600);
-	else canv_minus1sigma = new TCanvas(TString::Format("tanb-CLs_160_%d", (int)mass), "", 600, 600);
-	canv_minus1sigma->cd();
-	canv_minus1sigma->SetGridx(1);
-	canv_minus1sigma->SetGridy(1);
-	graph_minus1sigma->SetMaximum(10);
-	graph_minus1sigma->GetXaxis()->SetTitle("tan#beta");
-	graph_minus1sigma->GetXaxis()->SetLabelFont(62);
-	graph_minus1sigma->GetXaxis()->SetTitleFont(62);
-	graph_minus1sigma->GetXaxis()->SetTitleColor(1);
-	graph_minus1sigma->GetXaxis()->SetTitleOffset(1.05);
-	graph_minus1sigma->GetYaxis()->SetTitle("CL_{s}");
-	graph_minus1sigma->GetYaxis()->SetLabelFont(62);
-	graph_minus1sigma->GetYaxis()->SetTitleFont(62);
-	graph_minus1sigma->GetYaxis()->SetTitleOffset(1.05);
-	graph_minus1sigma->GetYaxis()->SetLabelSize(0.03);
-	graph_minus1sigma->SetMarkerStyle(20);
-	graph_minus1sigma->SetMarkerSize(1.3);
-	ymax=0; ymax=0;
-	for(int j=0; j<graph_minus1sigma->GetN(); j++){ 
-		if(graph_minus1sigma->GetY()[j]>ymax) {ymax=graph_minus1sigma->GetY()[j]; xmax=graph_minus1sigma->GetX()[j];}
-	}
-	graph_minus1sigma->Draw("AP");
-	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_minus1sigma->Print(TString::Format("%s/%0.1f/tanb-CLs_160_%0.1f.png", directory, mass, mass));
-	else canv_minus1sigma->Print(TString::Format("%s/%d/tanb-CLs_160_%d.png", directory, (int)mass, (int)mass));
-	//expected
-	TCanvas* canv_expected = new TCanvas();
-	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_expected = new TCanvas(TString::Format("tanb-CLs_EXP_%0.1f", mass), "", 600, 600);
-	else canv_expected = new TCanvas(TString::Format("tanb-CLs_EXP_%d", (int)mass), "", 600, 600);
-	canv_expected->cd();
-	canv_expected->SetGridx(1);
-	canv_expected->SetGridy(1);
-	graph_expected->SetMaximum(10);
-	graph_expected->GetXaxis()->SetTitle("tan#beta");
-	graph_expected->GetXaxis()->SetLabelFont(62);
-	graph_expected->GetXaxis()->SetTitleFont(62);
-	graph_expected->GetXaxis()->SetTitleColor(1);
-	graph_expected->GetXaxis()->SetTitleOffset(1.05);
-	graph_expected->GetYaxis()->SetTitle("CL_{s}");
-	graph_expected->GetYaxis()->SetLabelFont(62);
-	graph_expected->GetYaxis()->SetTitleFont(62);
-	graph_expected->GetYaxis()->SetTitleOffset(1.05);
-	graph_expected->GetYaxis()->SetLabelSize(0.03);
-	graph_expected->SetMarkerStyle(20);
-	graph_expected->SetMarkerSize(1.3);
-	ymax=0; ymax=0;
-	for(int j=0; j<graph_expected->GetN(); j++){ 
-		if(graph_expected->GetY()[j]>ymax) {ymax=graph_expected->GetY()[j]; xmax=graph_expected->GetX()[j];}
-	}
-	graph_expected->Draw("AP");
-	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_expected->Print(TString::Format("%s/%0.1f/tanb-CLs_EXP_%0.1f.png", directory, mass, mass));
-	else canv_expected->Print(TString::Format("%s/%d/tanb-CLs_EXP_%d.png", directory, (int)mass, (int)mass));
-	//plus1sigma
-	TCanvas* canv_plus1sigma = new TCanvas();
-	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_plus1sigma = new TCanvas(TString::Format("tanb-CLs_860_%0.1f", mass), "", 600, 600);
-	else canv_plus1sigma = new TCanvas(TString::Format("tanb-CLs_860_%d", (int)mass), "", 600, 600);
-	canv_plus1sigma->cd();
-	canv_plus1sigma->SetGridx(1);
-	canv_plus1sigma->SetGridy(1);
-	graph_plus1sigma->SetMaximum(10);
-	graph_plus1sigma->GetXaxis()->SetTitle("tan#beta");
-	graph_plus1sigma->GetXaxis()->SetLabelFont(62);
-	graph_plus1sigma->GetXaxis()->SetTitleFont(62);
-	graph_plus1sigma->GetXaxis()->SetTitleColor(1);
-	graph_plus1sigma->GetXaxis()->SetTitleOffset(1.05);
-	graph_plus1sigma->GetYaxis()->SetTitle("CL_{s}");
-	graph_plus1sigma->GetYaxis()->SetLabelFont(62);
-	graph_plus1sigma->GetYaxis()->SetTitleFont(62);
-	graph_plus1sigma->GetYaxis()->SetTitleOffset(1.05);
-	graph_plus1sigma->GetYaxis()->SetLabelSize(0.03);
-	graph_plus1sigma->SetMarkerStyle(20);
-	graph_plus1sigma->SetMarkerSize(1.3);
-	ymax=0; ymax=0;
-	for(int j=0; j<graph_plus1sigma->GetN(); j++){ 
-		if(graph_plus1sigma->GetY()[j]>ymax) {ymax=graph_plus1sigma->GetY()[j]; xmax=graph_plus1sigma->GetX()[j];}
-	}
-	graph_plus1sigma->Draw("AP");
-	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_plus1sigma->Print(TString::Format("%s/%0.1f/tanb-CLs_860_%0.1f.png", directory, mass, mass));
-	else canv_plus1sigma->Print(TString::Format("%s/%d/tanb-CLs_860_%d.png", directory, (int)mass, (int)mass));
-	//plus2sigma
-	TCanvas* canv_plus2sigma = new TCanvas();
-	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_plus2sigma = new TCanvas(TString::Format("tanb-CLs_975_%0.1f", mass), "", 600, 600);
-	else canv_plus2sigma = new TCanvas(TString::Format("tanb-CLs_975_%d", (int)mass), "", 600, 600);
-	canv_plus2sigma->cd();
-	canv_plus2sigma->SetGridx(1);
-	canv_plus2sigma->SetGridy(1);
-	graph_plus2sigma->SetMaximum(10);
-	graph_plus2sigma->GetXaxis()->SetTitle("tan#beta");
-	graph_plus2sigma->GetXaxis()->SetLabelFont(62);
-	graph_plus2sigma->GetXaxis()->SetTitleFont(62);
-	graph_plus2sigma->GetXaxis()->SetTitleColor(1);
-	graph_plus2sigma->GetXaxis()->SetTitleOffset(1.05);
-	graph_plus2sigma->GetYaxis()->SetTitle("CL_{s}");
-	graph_plus2sigma->GetYaxis()->SetLabelFont(62);
-	graph_plus2sigma->GetYaxis()->SetTitleFont(62);
-	graph_plus2sigma->GetYaxis()->SetTitleOffset(1.05);
-	graph_plus2sigma->GetYaxis()->SetLabelSize(0.03);
-	graph_plus2sigma->SetMarkerStyle(20);
-	graph_plus2sigma->SetMarkerSize(1.3);
-	ymax=0; ymax=0;
-	for(int j=0; j<graph_plus2sigma->GetN(); j++){ 
-		if(graph_plus2sigma->GetY()[j]>ymax) {ymax=graph_plus2sigma->GetY()[j]; xmax=graph_plus2sigma->GetX()[j];}
-	}
-	graph_plus2sigma->Draw("AP");
-	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_plus2sigma->Print(TString::Format("%s/%0.1f/tanb-CLs_975_%0.1f.png", directory, mass, mass));
-	else canv_plus2sigma->Print(TString::Format("%s/%d/tanb-CLs_975_%d.png", directory, (int)mass, (int)mass));
-	//observed
-	TCanvas* canv_observed = new TCanvas();
-	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_observed = new TCanvas(TString::Format("tanb-CLs_OBS_%0.1f", mass), "", 600, 600);
-	else canv_observed = new TCanvas(TString::Format("tanb-CLs_OBS_%d", (int)mass), "", 600, 600);
-	canv_observed->cd();
-	canv_observed->SetGridx(1);
-	canv_observed->SetGridy(1);
-	graph_observed->SetMaximum(10);
-	graph_observed->GetXaxis()->SetTitle("tan#beta");
-	graph_observed->GetXaxis()->SetLabelFont(62);
-	graph_observed->GetXaxis()->SetTitleFont(62);
-	graph_observed->GetXaxis()->SetTitleColor(1);
-	graph_observed->GetXaxis()->SetTitleOffset(1.05);
-	graph_observed->GetYaxis()->SetTitle("CL_{s}");
-	graph_observed->GetYaxis()->SetLabelFont(62);
-	graph_observed->GetYaxis()->SetTitleFont(62);
-	graph_observed->GetYaxis()->SetTitleOffset(1.05);
-	graph_observed->GetYaxis()->SetLabelSize(0.03);
-	graph_observed->SetMarkerStyle(20);
-	graph_observed->SetMarkerSize(1.3);
-	ymax=0; ymax=0;
-	for(int j=0; j<graph_observed->GetN(); j++){ 
-		if(graph_observed->GetY()[j]>ymax) {ymax=graph_observed->GetY()[j]; xmax=graph_observed->GetX()[j];}
-	}
-	graph_observed->Draw("AP");
-	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_observed->Print(TString::Format("%s/%0.1f/tanb-CLs_OBS_%0.1f.png", directory, mass, mass));
-	else canv_observed->Print(TString::Format("%s/%d/tanb-CLs_OBS_%d.png", directory, (int)mass, (int)mass));
-	return;
+  //control plots showing the CLs value over tanb for each mass
+  //minus2sigma
+  TCanvas* canv_minus2sigma = new TCanvas();
+  if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_minus2sigma = new TCanvas(TString::Format("tanb-CLs_025_%0.1f", mass), "", 600, 600);
+  else canv_minus2sigma = new TCanvas(TString::Format("tanb-CLs_025_%d", (int)mass), "", 600, 600);
+  canv_minus2sigma->cd();
+  canv_minus2sigma->SetGridx(1);
+  canv_minus2sigma->SetGridy(1);
+  graph_minus2sigma->SetMaximum(10);
+  graph_minus2sigma->GetXaxis()->SetTitle("tan#beta");
+  graph_minus2sigma->GetXaxis()->SetLabelFont(62);
+  graph_minus2sigma->GetXaxis()->SetTitleFont(62);
+  graph_minus2sigma->GetXaxis()->SetTitleColor(1);
+  graph_minus2sigma->GetXaxis()->SetTitleOffset(1.05);
+  graph_minus2sigma->GetYaxis()->SetTitle("CL_{s}");
+  graph_minus2sigma->GetYaxis()->SetLabelFont(62);
+  graph_minus2sigma->GetYaxis()->SetTitleFont(62);
+  graph_minus2sigma->GetYaxis()->SetTitleOffset(1.05);
+  graph_minus2sigma->GetYaxis()->SetLabelSize(0.03);
+  graph_minus2sigma->SetMarkerStyle(20);
+  graph_minus2sigma->SetMarkerSize(1.3);
+  ymax=0; ymax=0;
+  for(int j=0; j<graph_minus2sigma->GetN(); j++){ 
+    if(graph_minus2sigma->GetY()[j]>ymax) {ymax=graph_minus2sigma->GetY()[j]; xmax=graph_minus2sigma->GetX()[j];}
+  }
+  graph_minus2sigma->Draw("AP");
+  if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_minus2sigma->Print(TString::Format("%s/%0.1f/tanb-CLs_025_%0.1f.png", directory, mass, mass));
+  else canv_minus2sigma->Print(TString::Format("%s/%d/tanb-CLs_025_%d.png", directory, (int)mass, (int)mass));
+  //minus1sigma
+  TCanvas* canv_minus1sigma = new TCanvas();
+  if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_minus1sigma = new TCanvas(TString::Format("tanb-CLs_160_%0.1f", mass), "", 600, 600);
+  else canv_minus1sigma = new TCanvas(TString::Format("tanb-CLs_160_%d", (int)mass), "", 600, 600);
+  canv_minus1sigma->cd();
+  canv_minus1sigma->SetGridx(1);
+  canv_minus1sigma->SetGridy(1);
+  graph_minus1sigma->SetMaximum(10);
+  graph_minus1sigma->GetXaxis()->SetTitle("tan#beta");
+  graph_minus1sigma->GetXaxis()->SetLabelFont(62);
+  graph_minus1sigma->GetXaxis()->SetTitleFont(62);
+  graph_minus1sigma->GetXaxis()->SetTitleColor(1);
+  graph_minus1sigma->GetXaxis()->SetTitleOffset(1.05);
+  graph_minus1sigma->GetYaxis()->SetTitle("CL_{s}");
+  graph_minus1sigma->GetYaxis()->SetLabelFont(62);
+  graph_minus1sigma->GetYaxis()->SetTitleFont(62);
+  graph_minus1sigma->GetYaxis()->SetTitleOffset(1.05);
+  graph_minus1sigma->GetYaxis()->SetLabelSize(0.03);
+  graph_minus1sigma->SetMarkerStyle(20);
+  graph_minus1sigma->SetMarkerSize(1.3);
+  ymax=0; ymax=0;
+  for(int j=0; j<graph_minus1sigma->GetN(); j++){ 
+    if(graph_minus1sigma->GetY()[j]>ymax) {ymax=graph_minus1sigma->GetY()[j]; xmax=graph_minus1sigma->GetX()[j];}
+  }
+  graph_minus1sigma->Draw("AP");
+  if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_minus1sigma->Print(TString::Format("%s/%0.1f/tanb-CLs_160_%0.1f.png", directory, mass, mass));
+  else canv_minus1sigma->Print(TString::Format("%s/%d/tanb-CLs_160_%d.png", directory, (int)mass, (int)mass));
+  //expected
+  TCanvas* canv_expected = new TCanvas();
+  if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_expected = new TCanvas(TString::Format("tanb-CLs_EXP_%0.1f", mass), "", 600, 600);
+  else canv_expected = new TCanvas(TString::Format("tanb-CLs_EXP_%d", (int)mass), "", 600, 600);
+  canv_expected->cd();
+  canv_expected->SetGridx(1);
+  canv_expected->SetGridy(1);
+  graph_expected->SetMaximum(10);
+  graph_expected->GetXaxis()->SetTitle("tan#beta");
+  graph_expected->GetXaxis()->SetLabelFont(62);
+  graph_expected->GetXaxis()->SetTitleFont(62);
+  graph_expected->GetXaxis()->SetTitleColor(1);
+  graph_expected->GetXaxis()->SetTitleOffset(1.05);
+  graph_expected->GetYaxis()->SetTitle("CL_{s}");
+  graph_expected->GetYaxis()->SetLabelFont(62);
+  graph_expected->GetYaxis()->SetTitleFont(62);
+  graph_expected->GetYaxis()->SetTitleOffset(1.05);
+  graph_expected->GetYaxis()->SetLabelSize(0.03);
+  graph_expected->SetMarkerStyle(20);
+  graph_expected->SetMarkerSize(1.3);
+  ymax=0; ymax=0;
+  for(int j=0; j<graph_expected->GetN(); j++){ 
+    if(graph_expected->GetY()[j]>ymax) {ymax=graph_expected->GetY()[j]; xmax=graph_expected->GetX()[j];}
+  }
+  graph_expected->Draw("AP");
+  if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_expected->Print(TString::Format("%s/%0.1f/tanb-CLs_EXP_%0.1f.png", directory, mass, mass));
+  else canv_expected->Print(TString::Format("%s/%d/tanb-CLs_EXP_%d.png", directory, (int)mass, (int)mass));
+  //plus1sigma
+  TCanvas* canv_plus1sigma = new TCanvas();
+  if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_plus1sigma = new TCanvas(TString::Format("tanb-CLs_860_%0.1f", mass), "", 600, 600);
+  else canv_plus1sigma = new TCanvas(TString::Format("tanb-CLs_860_%d", (int)mass), "", 600, 600);
+  canv_plus1sigma->cd();
+  canv_plus1sigma->SetGridx(1);
+  canv_plus1sigma->SetGridy(1);
+  graph_plus1sigma->SetMaximum(10);
+  graph_plus1sigma->GetXaxis()->SetTitle("tan#beta");
+  graph_plus1sigma->GetXaxis()->SetLabelFont(62);
+  graph_plus1sigma->GetXaxis()->SetTitleFont(62);
+  graph_plus1sigma->GetXaxis()->SetTitleColor(1);
+  graph_plus1sigma->GetXaxis()->SetTitleOffset(1.05);
+  graph_plus1sigma->GetYaxis()->SetTitle("CL_{s}");
+  graph_plus1sigma->GetYaxis()->SetLabelFont(62);
+  graph_plus1sigma->GetYaxis()->SetTitleFont(62);
+  graph_plus1sigma->GetYaxis()->SetTitleOffset(1.05);
+  graph_plus1sigma->GetYaxis()->SetLabelSize(0.03);
+  graph_plus1sigma->SetMarkerStyle(20);
+  graph_plus1sigma->SetMarkerSize(1.3);
+  ymax=0; ymax=0;
+  for(int j=0; j<graph_plus1sigma->GetN(); j++){ 
+    if(graph_plus1sigma->GetY()[j]>ymax) {ymax=graph_plus1sigma->GetY()[j]; xmax=graph_plus1sigma->GetX()[j];}
+  }
+  graph_plus1sigma->Draw("AP");
+  if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_plus1sigma->Print(TString::Format("%s/%0.1f/tanb-CLs_860_%0.1f.png", directory, mass, mass));
+  else canv_plus1sigma->Print(TString::Format("%s/%d/tanb-CLs_860_%d.png", directory, (int)mass, (int)mass));
+  //plus2sigma
+  TCanvas* canv_plus2sigma = new TCanvas();
+  if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_plus2sigma = new TCanvas(TString::Format("tanb-CLs_975_%0.1f", mass), "", 600, 600);
+  else canv_plus2sigma = new TCanvas(TString::Format("tanb-CLs_975_%d", (int)mass), "", 600, 600);
+  canv_plus2sigma->cd();
+  canv_plus2sigma->SetGridx(1);
+  canv_plus2sigma->SetGridy(1);
+  graph_plus2sigma->SetMaximum(10);
+  graph_plus2sigma->GetXaxis()->SetTitle("tan#beta");
+  graph_plus2sigma->GetXaxis()->SetLabelFont(62);
+  graph_plus2sigma->GetXaxis()->SetTitleFont(62);
+  graph_plus2sigma->GetXaxis()->SetTitleColor(1);
+  graph_plus2sigma->GetXaxis()->SetTitleOffset(1.05);
+  graph_plus2sigma->GetYaxis()->SetTitle("CL_{s}");
+  graph_plus2sigma->GetYaxis()->SetLabelFont(62);
+  graph_plus2sigma->GetYaxis()->SetTitleFont(62);
+  graph_plus2sigma->GetYaxis()->SetTitleOffset(1.05);
+  graph_plus2sigma->GetYaxis()->SetLabelSize(0.03);
+  graph_plus2sigma->SetMarkerStyle(20);
+  graph_plus2sigma->SetMarkerSize(1.3);
+  ymax=0; ymax=0;
+  for(int j=0; j<graph_plus2sigma->GetN(); j++){ 
+    if(graph_plus2sigma->GetY()[j]>ymax) {ymax=graph_plus2sigma->GetY()[j]; xmax=graph_plus2sigma->GetX()[j];}
+  }
+  graph_plus2sigma->Draw("AP");
+  if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_plus2sigma->Print(TString::Format("%s/%0.1f/tanb-CLs_975_%0.1f.png", directory, mass, mass));
+  else canv_plus2sigma->Print(TString::Format("%s/%d/tanb-CLs_975_%d.png", directory, (int)mass, (int)mass));
+  //observed
+  TCanvas* canv_observed = new TCanvas();
+  if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_observed = new TCanvas(TString::Format("tanb-CLs_OBS_%0.1f", mass), "", 600, 600);
+  else canv_observed = new TCanvas(TString::Format("tanb-CLs_OBS_%d", (int)mass), "", 600, 600);
+  canv_observed->cd();
+  canv_observed->SetGridx(1);
+  canv_observed->SetGridy(1);
+  graph_observed->SetMaximum(10);
+  graph_observed->GetXaxis()->SetTitle("tan#beta");
+  graph_observed->GetXaxis()->SetLabelFont(62);
+  graph_observed->GetXaxis()->SetTitleFont(62);
+  graph_observed->GetXaxis()->SetTitleColor(1);
+  graph_observed->GetXaxis()->SetTitleOffset(1.05);
+  graph_observed->GetYaxis()->SetTitle("CL_{s}");
+  graph_observed->GetYaxis()->SetLabelFont(62);
+  graph_observed->GetYaxis()->SetTitleFont(62);
+  graph_observed->GetYaxis()->SetTitleOffset(1.05);
+  graph_observed->GetYaxis()->SetLabelSize(0.03);
+  graph_observed->SetMarkerStyle(20);
+  graph_observed->SetMarkerSize(1.3);
+  ymax=0; ymax=0;
+  for(int j=0; j<graph_observed->GetN(); j++){ 
+    if(graph_observed->GetY()[j]>ymax) {ymax=graph_observed->GetY()[j]; xmax=graph_observed->GetX()[j];}
+  }
+  graph_observed->Draw("AP");
+  if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_observed->Print(TString::Format("%s/%0.1f/tanb-CLs_OBS_%0.1f.png", directory, mass, mass));
+  else canv_observed->Print(TString::Format("%s/%d/tanb-CLs_OBS_%d.png", directory, (int)mass, (int)mass));
+  return;
 }
 

--- a/src/Tanb.cc
+++ b/src/Tanb.cc
@@ -8,405 +8,489 @@
 /// root macros. It is therefore not element of the PlotLimits class.
 void plottingTanb(TCanvas& canv, TH2D* h2d, std::vector<TGraph*> minus2sigma, std::vector<TGraph*> minus1sigma, std::vector<TGraph*> expected, std::vector<TGraph*> plus1sigma, std::vector<TGraph*> plus2sigma, std::vector<TGraph*> observed, std::vector<TGraph*> injected, std::map<double, TGraphAsymmErrors*> higgsBands,std::map<double,std::vector<TGraph*>> higgsBandsContour, std::map<std::string, TGraph*> comparisons, std::string& xaxis, std::string& yaxis, std::string& theory, double min=0., double max=50., bool log=false, bool transparent=false, bool expectedOnly=false, bool MSSMvsSM=true, std::string HIG="", bool Brazilian=false, bool azh=false);
 void contour2D(TString xvar, int xbins, float xmin, float xmax, TString yvar, int ybins, float ymin, float ymax, float smx=1.0, float smy=1.0, TFile *fOut=0, TString name="contour2D");
-TList* contourFromTH2(TH2 *h2in, double threshold, int minPoints=20, bool require_minPoints=true);
+TList* contourFromTH2(TH2 *h2in, double threshold, int minPoints=20, bool require_minPoints=true,double multip=1.);
 
 void CLsControlPlots(TGraph* graph_minus2sigma, TGraph* graph_minus1sigma, TGraph* graph_expected, TGraph* graph_plus1sigma, TGraph* graph_plus2sigma, TGraph* graph_observed, const char* directory, float mass, int max, int ymax, const char* model);
 
 struct STestFunctor{
-  STestFunctor() { sum = 0; }
-  void operator() (TObject *aObj) {sum +=1;}
-  int sum;
+	STestFunctor() { sum = 0; }
+	void operator() (TObject *aObj) {sum +=1;}
+	int sum;
 } stestfunctor;
 
 struct myclass {
-  bool operator() (int i,int j) { return (i<j);}
+	bool operator() (int i,int j) { return (i<j);}
 } myobject;
 
-void
+	void
 PlotLimits::plotTanb(TCanvas& canv, const char* directory, std::string HIG)
 {
-  //separate between MSSMvsSM and MSSMvsBG
-  double exclusion_=0;
-  if(MSSMvsSM_) exclusion_=0.05;
-  else exclusion_=1;
-  //different MSSM scenarios
-  std::string extralabel_ = "";
-  const char* model;
-  double tanbHigh=0, tanbLow=0, tanbLowHigh=0;
-  tanbHigh=tanbLow+tanbLowHigh;
-  if(theory_=="MSSM m_{h}^{max} scenario") {extralabel_= "mhmax-"; model = "mhmax-mu+200"; tanbHigh=60; tanbLow=0.5; tanbLowHigh=2;}
-  if(theory_=="MSSM m_{h}^{mod-} scenario") {extralabel_= "mhmodm-"; model = "mhmodm"; tanbHigh=60; tanbLow=0.5; tanbLowHigh=2;}
-  if(theory_=="MSSM m_{h}^{mod+} scenario") {extralabel_= "mhmodp-"; model = "mhmodp"; tanbHigh=60; tanbLow=0.5; tanbLowHigh=2;}
-  if(theory_=="MSSM low-m_{H} scenario") {extralabel_= "lowmH-"; model = "lowmH"; tanbHigh=9.5; tanbLow=1.5; tanbLowHigh=2;}
-  if(theory_=="MSSM light-stau scenario") {extralabel_= "lightstau1-"; model = "lightstau1"; tanbHigh=60; tanbLow=0.5; tanbLowHigh=3;}
-  if(theory_=="MSSM #scale[1.3]{#bf{#tau}}-phobic scenario") {extralabel_= "tauphobic-"; model = "tauphobic"; tanbHigh=50; tanbLow=1.0; tanbLowHigh=2;}
-  if(theory_=="MSSM light-stop scenario") {extralabel_= "lightstopmod-"; model = "lightstopmod"; tanbHigh=60; tanbLow=0.7; tanbLowHigh=2;}
-  if(theory_=="MSSM low-tan#beta-high scenario") {extralabel_= "low-tb-high-"; model = "low-tb-high"; tanbHigh=9.5; tanbLow=0.5; tanbLowHigh=2;}
-  if(theory_=="2HDM type-I") {extralabel_= "2HDMtyp1-"; model = "2HDMtyp1"; tanbHigh=10; tanbLow=1; tanbLowHigh=2;}
-  if(theory_=="2HDM type-II") {extralabel_= "2HDMtyp2-"; model = "2HDMtyp2"; tanbHigh=10; tanbLow=1; tanbLowHigh=2;}
- 
-  // set up styles
-  SetStyle();
+	//separate between MSSMvsSM and MSSMvsBG
+	double exclusion_=0;
+	if(MSSMvsSM_) exclusion_=0.05;
+	else exclusion_=1;
+	//different MSSM scenarios
+	std::string extralabel_ = "";
+	const char* model;
+	double tanbHigh=0, tanbLow=0, tanbLowHigh=0;
+	tanbHigh=tanbLow+tanbLowHigh;
+	if(theory_=="MSSM m_{h}^{max} scenario") {extralabel_= "mhmax-"; model = "mhmax-mu+200"; tanbHigh=60; tanbLow=0.5; tanbLowHigh=2;}
+	if(theory_=="MSSM m_{h}^{mod-} scenario") {extralabel_= "mhmodm-"; model = "mhmodm"; tanbHigh=60; tanbLow=0.5; tanbLowHigh=2;}
+	if(theory_=="MSSM m_{h}^{mod+} scenario") {extralabel_= "mhmodp-"; model = "mhmodp"; tanbHigh=60; tanbLow=0.5; tanbLowHigh=2;}
+	if(theory_=="MSSM low-m_{H} scenario") {extralabel_= "lowmH-"; model = "lowmH"; tanbHigh=9.5; tanbLow=1.5; tanbLowHigh=2;}
+	if(theory_=="MSSM light-stau scenario") {extralabel_= "lightstau1-"; model = "lightstau1"; tanbHigh=60; tanbLow=0.5; tanbLowHigh=3;}
+	if(theory_=="MSSM #scale[1.3]{#bf{#tau}}-phobic scenario") {extralabel_= "tauphobic-"; model = "tauphobic"; tanbHigh=50; tanbLow=1.0; tanbLowHigh=2;}
+	if(theory_=="MSSM light-stop scenario") {extralabel_= "lightstopmod-"; model = "lightstopmod"; tanbHigh=60; tanbLow=0.7; tanbLowHigh=2;}
+	if(theory_=="MSSM low-tan#beta-high scenario") {extralabel_= "low-tb-high-"; model = "low-tb-high"; tanbHigh=9.5; tanbLow=0.5; tanbLowHigh=2;}
+	if(theory_=="2HDM type-I") {extralabel_= "2HDMtyp1-"; model = "2HDMtyp1"; tanbHigh=10; tanbLow=1; tanbLowHigh=2;}
+	if(theory_=="2HDM type-II") {extralabel_= "2HDMtyp2-"; model = "2HDMtyp2"; tanbHigh=10; tanbLow=1; tanbLowHigh=2;}
 
-  //vectors of graphs from the tanb-CLs control plots used for tex/txt printing
-  std::vector<TGraph*> v_graph_minus2sigma;
-  std::vector<TGraph*> v_graph_minus1sigma;
-  std::vector<TGraph*> v_graph_expected;
-  std::vector<TGraph*> v_graph_plus1sigma;
-  std::vector<TGraph*> v_graph_plus2sigma;
-  std::vector<TGraph*> v_graph_observed;
-  float masses[50];
+	// set up styles
+	SetStyle();
 
-  int nxbins=0;
-  int array_number=0;
-  if(model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2")) array_number = (int)((bins_[bins_.size()-1]-bins_[0])/0.02)+1;
-  else array_number = (int)(bins_[bins_.size()-1]-bins_[0])/10+1; 
-  //else array_number = (int)bins_.size();
-  Double_t xbins[array_number];
-  
-  if(model!=TString::Format("2HDMtyp1") && model!=TString::Format("2HDMtyp2")){
-    for(float mass=bins_[0]; mass<bins_[bins_.size()-1]+1; mass=mass+10){
-      xbins[nxbins]=mass;
-      nxbins++;;
-    }
-    xbins[nxbins]=bins_[bins_.size()-1]+1;
-  }
-  else {
-    for(double mass=bins_[0]; mass<bins_[bins_.size()-1]+0.01; mass=mass+0.02){
-      xbins[nxbins]=mass;
-      nxbins++;
-    }
-    xbins[nxbins]=bins_[bins_.size()-1]+0.01;
-  }
+	//vectors of graphs from the tanb-CLs control plots used for tex/txt printing
+	std::vector<TGraph*> v_graph_minus2sigma;
+	std::vector<TGraph*> v_graph_minus1sigma;
+	std::vector<TGraph*> v_graph_expected;
+	std::vector<TGraph*> v_graph_plus1sigma;
+	std::vector<TGraph*> v_graph_plus2sigma;
+	std::vector<TGraph*> v_graph_observed;
+	float masses[50];
 
-  TH2D *plane_minus2sigma = 0, *plane_minus1sigma = 0, *plane_expected = 0, *plane_plus1sigma = 0, *plane_plus2sigma = 0, *plane_observed = 0;
-  if(model!=TString::Format("lowmH")) {
-    plane_minus2sigma = new TH2D("minus2sigma","minus2sigma", nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-    plane_minus1sigma = new TH2D("minus1sigma","minus1sigma", nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-    plane_expected    = new TH2D("expected","expected",       nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-    plane_plus1sigma  = new TH2D("plus1sigma","plus1sigma",   nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-    plane_plus2sigma  = new TH2D("plus2sigma","plus2sigma",   nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-    plane_observed    = new TH2D("observed","observed",       nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-  }
-  else { 
-    plane_minus2sigma = new TH2D("minus2sigma","minus2sigma", 29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-    plane_minus1sigma = new TH2D("minus1sigma","minus1sigma", 29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-    plane_expected    = new TH2D("expected",   "expected",    29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-    plane_plus1sigma  = new TH2D("plus1sigma","plus1sigma",   29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-    plane_plus2sigma  = new TH2D("plus2sigma","plus2sigma",   29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-    plane_observed    = new TH2D("observed","observed",       29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
-  }
+	int nxbins=0;
+	int array_number=0;
+	if(model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2")) array_number = (int)((bins_[bins_.size()-1]-bins_[0])/0.02)+1;
+	else array_number = (int)(bins_[bins_.size()-1]-bins_[0])/10+1; 
+	//else array_number = (int)bins_.size();
+	Double_t xbins[array_number];
 
-  for(int idx=1; idx<plane_minus2sigma->GetNbinsX()+1; idx++){
-    for(int idy=1; idy<plane_minus2sigma->GetNbinsY()+1; idy++){
-      plane_minus2sigma->SetBinContent(idx, idy, 1.1);
-      plane_minus1sigma->SetBinContent(idx, idy, 1.1);
-      plane_expected   ->SetBinContent(idx, idy, 1.1);
-      plane_plus1sigma ->SetBinContent(idx, idy, 1.1);
-      plane_plus2sigma ->SetBinContent(idx, idy, 1.1);
-      plane_observed   ->SetBinContent(idx, idy, 1.1);
-    }
-  }
-
-  if(HIG != ""){
-    std::cout << "NO LONGER SUPPORTED" << std::endl;
-  }
-  else{
-    //int ipoint_exp=0, ipoint_obs=0;
-    for(unsigned int imass=0; imass<bins_.size(); ++imass){
-      // buffer mass value
-      float mass = bins_[imass];    
-      //control plots
-      TGraph* graph_minus2sigma = new TGraph();
-      TGraph* graph_minus1sigma = new TGraph();
-      TGraph* graph_expected = new TGraph();
-      TGraph* graph_plus1sigma = new TGraph();
-      TGraph* graph_plus2sigma = new TGraph();
-      TGraph* graph_observed = new TGraph();
-      
-      TString fullpath = TString::Format("%s/%d/HypothesisTest.root", directory, (int)mass);
-      if (model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2")){ 
-        if(bins_[imass]!=(int)bins_[imass]) fullpath = TString::Format("%s/%0.1f/HypothesisTest.root", directory, bins_[imass]);
-        else fullpath = TString::Format("%s/%d/HypothesisTest.root",directory,(int)mass);
-      }
-      std::cout << "open file: " << fullpath << std::endl;
-      TFile* file_ = TFile::Open(fullpath); if(!file_){ std::cout << "--> TFile is corrupt: skipping masspoint." << std::endl; continue; }
-      TTree* limit = (TTree*) file_->Get("tree"); if(!limit){ std::cout << "--> TTree is corrupt: skipping masspoint." << std::endl; continue; }
-      double tanb, exp, obs, plus1sigma, minus1sigma, plus2sigma, minus2sigma;
-      limit->SetBranchAddress("tanb", &tanb );  
-      limit->SetBranchAddress("minus2sigma", &minus2sigma);
-      limit->SetBranchAddress("minus1sigma", &minus1sigma);
-      limit->SetBranchAddress("expected", &exp);
-      limit->SetBranchAddress("plus1sigma", &plus1sigma); 
-      limit->SetBranchAddress("plus2sigma", &plus2sigma);  
-      limit->SetBranchAddress("observed", &obs);  
-      int nevent = limit->GetEntries();   
-      //Drawing variable tanb with no graphics option.
-      //variable tanb stored in array fV1 (see TTree::Draw)
-      limit->Draw("tanb","","goff");
-      Int_t *index = new Int_t[nevent];
-      //sort array containing tanb in decreasing order
-      //The array index contains the entry numbers in increasing order in respect to tanb
-      TMath::Sort(nevent,limit->GetV1(),index,false); //changed from true (=default) =decreasing order
-      int k=0; double xmax=0; double ymax=0; //stuff needed for fitting;
-      // loop to find the crosspoint between low and high exclusion (tanbLowHigh)_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), plane_observed   ->GetYaxis()->FindBin(tanb), obs/exclusion_);
-      for(int i=0; i<nevent; ++i){
-	limit->GetEntry(index[i]);
-	//filling control plots
-	graph_minus2sigma->SetPoint(k, tanb, minus2sigma/exclusion_);
-	graph_minus1sigma->SetPoint(k, tanb, minus1sigma/exclusion_);
-	graph_expected   ->SetPoint(k, tanb, exp/exclusion_);
-	graph_plus1sigma ->SetPoint(k, tanb, plus1sigma/exclusion_);
-	graph_plus2sigma ->SetPoint(k, tanb, plus2sigma/exclusion_);
-	graph_observed   ->SetPoint(k, tanb, obs/exclusion_);
-	k++;      
-	for(int j=0; j<graph_minus2sigma->GetN(); j++){ 
-	  if(graph_minus2sigma->GetY()[j]>ymax && graph_minus2sigma->GetX()[j]>=1) {ymax=graph_minus2sigma->GetY()[j]; xmax=graph_minus2sigma->GetX()[j]; tanbLowHigh=xmax;} //tanb>=1 hardcoded to fix that point 	  
+	if(model!=TString::Format("2HDMtyp1") && model!=TString::Format("2HDMtyp2")){
+		for(float mass=bins_[0]; mass<bins_[bins_.size()-1]+1; mass=mass+10){
+			xbins[nxbins]=mass;
+			nxbins++;;
+		}
+		xbins[nxbins]=bins_[bins_.size()-1]+1;
 	}
-	// Fill TH2D with calculated limit points
-	plane_minus2sigma->SetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), plane_minus2sigma->GetYaxis()->FindBin(tanb), minus2sigma/exclusion_);
-	plane_minus1sigma->SetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), plane_minus1sigma->GetYaxis()->FindBin(tanb), minus1sigma/exclusion_);
-	plane_expected   ->SetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), plane_expected   ->GetYaxis()->FindBin(tanb), exp/exclusion_);
-	plane_plus1sigma ->SetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), plane_plus1sigma ->GetYaxis()->FindBin(tanb), plus1sigma/exclusion_);
-	plane_plus2sigma ->SetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), plane_plus2sigma ->GetYaxis()->FindBin(tanb), plus2sigma/exclusion_);
-	plane_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), plane_observed   ->GetYaxis()->FindBin(tanb), obs/exclusion_);
-      }	
-
-      //control plot plotting
-      CLsControlPlots(graph_minus2sigma, graph_minus1sigma, graph_expected, graph_plus1sigma, graph_plus2sigma, graph_observed, directory, mass, xmax, ymax, model);
-
-      //push back graphs and save mass for tex/txt output printing
-      v_graph_minus2sigma.push_back(graph_minus2sigma);
-      v_graph_minus1sigma.push_back(graph_minus1sigma);
-      v_graph_expected.push_back(graph_expected);
-      v_graph_plus1sigma.push_back(graph_plus1sigma);
-      v_graph_plus2sigma.push_back(graph_plus2sigma);
-      v_graph_observed.push_back(graph_observed);
-      masses[imass]=mass;
-
-      // Interpolation along the y-axis for filling everything in between
-      limit->GetEntry(index[0]);
-      float tbmin=tanb; 
-      limit->GetEntry(index[nevent-1]);
-      float tbmax=tanb; 
-      for(int idy=1; idy<plane_minus2sigma->GetNbinsY()+1; idy++){
-	if (plane_minus2sigma->GetYaxis()->GetBinCenter(idy) > tbmin && plane_minus2sigma->GetYaxis()->GetBinCenter(idy) < tbmax ){
-	  if(linearFit_){
-	    plane_minus2sigma->SetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), idy, graph_minus2sigma->Eval(plane_minus2sigma->GetYaxis()->GetBinCenter(idy)));
-	    plane_minus1sigma->SetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), idy, graph_minus1sigma->Eval(plane_minus1sigma->GetYaxis()->GetBinCenter(idy)));
-	    plane_expected   ->SetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), idy, graph_expected   ->Eval(plane_expected   ->GetYaxis()->GetBinCenter(idy)));
-	    plane_plus1sigma ->SetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), idy, graph_plus1sigma ->Eval(plane_plus1sigma ->GetYaxis()->GetBinCenter(idy)));
-	    plane_plus2sigma ->SetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), idy, graph_plus2sigma ->Eval(plane_plus2sigma ->GetYaxis()->GetBinCenter(idy)));
-	    plane_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), idy, graph_observed   ->Eval(plane_observed   ->GetYaxis()->GetBinCenter(idy)));
-	  }
-	  else{
-	    plane_minus2sigma->SetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), idy, graph_minus2sigma->Eval(plane_minus2sigma->GetYaxis()->GetBinCenter(idy), 0, "S"));
-	    plane_minus1sigma->SetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), idy, graph_minus1sigma->Eval(plane_minus1sigma->GetYaxis()->GetBinCenter(idy), 0, "S"));
-	    plane_expected   ->SetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), idy, graph_expected   ->Eval(plane_expected   ->GetYaxis()->GetBinCenter(idy), 0, "S"));
-	    plane_plus1sigma ->SetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), idy, graph_plus1sigma ->Eval(plane_plus1sigma ->GetYaxis()->GetBinCenter(idy), 0, "S"));
-	    plane_plus2sigma ->SetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), idy, graph_plus2sigma ->Eval(plane_plus2sigma ->GetYaxis()->GetBinCenter(idy), 0, "S"));
-	    plane_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), idy, graph_observed   ->Eval(plane_observed   ->GetYaxis()->GetBinCenter(idy), 0, "S"));
-	  }
+	else {
+		for(double mass=bins_[0]; mass<bins_[bins_.size()-1]+0.01; mass=mass+0.02){
+			xbins[nxbins]=mass;
+			nxbins++;
+		}
+		xbins[nxbins]=bins_[bins_.size()-1]+0.01;
 	}
-	else if(plane_minus2sigma->GetYaxis()->GetBinCenter(idy) < tbmin){
-	  plane_minus2sigma->SetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), idy, graph_minus2sigma->GetY()[0]);
-	  plane_minus1sigma->SetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), idy, graph_minus1sigma->GetY()[0]);
-	  plane_expected   ->SetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), idy, graph_expected   ->GetY()[0]);
-	  plane_plus1sigma ->SetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), idy, graph_plus1sigma ->GetY()[0]);
-	  plane_plus2sigma ->SetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), idy, graph_plus2sigma ->GetY()[0]);
-	  plane_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), idy, graph_observed   ->GetY()[0]);
-	}
-	else if(plane_minus2sigma->GetYaxis()->GetBinCenter(idy) > tbmax){
-	  plane_minus2sigma->SetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), idy, graph_minus2sigma->GetY()[graph_minus2sigma->GetN()-1]);
-	  plane_minus1sigma->SetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), idy, graph_minus1sigma->GetY()[graph_minus1sigma->GetN()-1]);
-	  plane_expected   ->SetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), idy, graph_expected   ->GetY()[graph_expected   ->GetN()-1]);
-	  plane_plus1sigma ->SetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), idy, graph_plus1sigma ->GetY()[graph_plus1sigma ->GetN()-1]);
-	  plane_plus2sigma ->SetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), idy, graph_plus2sigma ->GetY()[graph_plus2sigma ->GetN()-1]);
-	  plane_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), idy, graph_observed   ->GetY()[graph_observed   ->GetN()-1]);
-	}
-      }
-    }
-  }	
 
-  // Interpolation along the x-axis for filling everything in between
-  for(int idy=0; idy<plane_minus2sigma->GetNbinsY()+1; idy++){
-    TGraph* graph_minus2sigma_tanb = new TGraph();
-    TGraph* graph_minus1sigma_tanb = new TGraph();
-    TGraph* graph_expected_tanb = new TGraph();
-    TGraph* graph_plus1sigma_tanb = new TGraph();
-    TGraph* graph_plus2sigma_tanb = new TGraph();
-    TGraph* graph_observed_tanb = new TGraph();
-    for(unsigned int imass=0; imass<bins_.size(); ++imass){
-      // buffer mass value
-      float mass = bins_[imass];
-      graph_minus2sigma_tanb->SetPoint(imass, mass, plane_minus2sigma->GetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), idy));
-      graph_minus1sigma_tanb->SetPoint(imass, mass, plane_minus1sigma->GetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), idy));
-      graph_expected_tanb   ->SetPoint(imass, mass, plane_expected   ->GetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), idy));
-      graph_plus1sigma_tanb ->SetPoint(imass, mass, plane_plus1sigma ->GetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), idy));
-      graph_plus2sigma_tanb ->SetPoint(imass, mass, plane_plus2sigma ->GetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), idy));
-      graph_observed_tanb   ->SetPoint(imass, mass, plane_observed   ->GetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), idy));
-    }
-    for(int idx=0; idx<plane_minus2sigma->GetNbinsX()+1; idx++)
-      {
-	if(linearFit_){
-	  plane_minus2sigma->SetBinContent(idx, idy, graph_minus2sigma_tanb->Eval(plane_minus2sigma->GetXaxis()->GetBinCenter(idx)));
-	  plane_minus1sigma->SetBinContent(idx, idy, graph_minus1sigma_tanb->Eval(plane_minus1sigma->GetXaxis()->GetBinCenter(idx)));
-	  plane_expected   ->SetBinContent(idx, idy, graph_expected_tanb   ->Eval(plane_expected   ->GetXaxis()->GetBinCenter(idx)));
-	  plane_plus1sigma ->SetBinContent(idx, idy, graph_plus1sigma_tanb ->Eval(plane_plus1sigma ->GetXaxis()->GetBinCenter(idx)));
-	  plane_plus2sigma ->SetBinContent(idx, idy, graph_plus2sigma_tanb ->Eval(plane_plus2sigma ->GetXaxis()->GetBinCenter(idx)));
-	  plane_observed   ->SetBinContent(idx, idy, graph_observed_tanb   ->Eval(plane_observed   ->GetXaxis()->GetBinCenter(idx)));
+	TH2D *plane_minus2sigma = 0, *plane_minus1sigma = 0, *plane_expected = 0, *plane_plus1sigma = 0, *plane_plus2sigma = 0, *plane_observed = 0;
+
+	if(model!=TString::Format("lowmH")) {
+		plane_minus2sigma = new TH2D("minus2sigma","minus2sigma", nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+		plane_minus1sigma = new TH2D("minus1sigma","minus1sigma", nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+		plane_expected    = new TH2D("expected","expected",       nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+		plane_plus1sigma  = new TH2D("plus1sigma","plus1sigma",   nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+		plane_plus2sigma  = new TH2D("plus2sigma","plus2sigma",   nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+		plane_observed    = new TH2D("observed","observed",       nxbins, xbins, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+	}
+	else { 
+		plane_minus2sigma = new TH2D("minus2sigma","minus2sigma", 29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+		plane_minus1sigma = new TH2D("minus1sigma","minus1sigma", 29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+		plane_expected    = new TH2D("expected",   "expected",    29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+		plane_plus1sigma  = new TH2D("plus1sigma","plus1sigma",   29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+		plane_plus2sigma  = new TH2D("plus2sigma","plus2sigma",   29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+		plane_observed    = new TH2D("observed","observed",       29, 300, 3100, (int)((tanbHigh-tanbLow)*10-1), tanbLow, tanbHigh);
+	}
+
+
+	for(int idx=1; idx<plane_minus2sigma->GetNbinsX()+1; idx++){
+		for(int idy=1; idy<plane_minus2sigma->GetNbinsY()+1; idy++){
+			plane_minus2sigma->SetBinContent(idx, idy, 1.1);
+			plane_minus1sigma->SetBinContent(idx, idy, 1.1);
+			plane_expected   ->SetBinContent(idx, idy, 1.1);
+			plane_plus1sigma ->SetBinContent(idx, idy, 1.1);
+			plane_plus2sigma ->SetBinContent(idx, idy, 1.1);
+			plane_observed   ->SetBinContent(idx, idy, 1.1);
+		}
+	}
+
+	TGraph2D* graph_minus2sigma_2d = new TGraph2D();
+	TGraph2D* graph_minus1sigma_2d = new TGraph2D();
+	TGraph2D* graph_expected_2d = new TGraph2D();
+	TGraph2D* graph_plus1sigma_2d = new TGraph2D();
+	TGraph2D* graph_plus2sigma_2d = new TGraph2D();
+	TGraph2D* graph_observed_2d = new TGraph2D();
+	graph_minus2sigma_2d->SetTitle("");
+	graph_minus1sigma_2d->SetTitle("");
+	graph_expected_2d->SetTitle("");
+	graph_plus1sigma_2d->SetTitle("");
+	graph_plus2sigma_2d->SetTitle("");
+	graph_observed_2d->SetTitle("");
+
+	TH2D *minus2sigma_th2d =new TH2D("minus2sigma_th2d","minus2sigma_th2d",4*nxbins,xbins[0],xbins[nxbins-1],(int)((tanbHigh-tanbLow)*10-1),tanbLow,tanbHigh);
+	TH2D *minus1sigma_th2d =new TH2D("minus1sigma_th2d","minus1sigma_th2d",4*nxbins,xbins[0],xbins[nxbins-1],(int)((tanbHigh-tanbLow)*10-1),tanbLow,tanbHigh);
+	TH2D *expected_th2d =new TH2D("expected_th2d","expected_th2d",4*nxbins,xbins[0],xbins[nxbins-1],(int)((tanbHigh-tanbLow)*10-1),tanbLow,tanbHigh);
+	TH2D *plus1sigma_th2d =new TH2D("plus1sigma_th2d","plus1sigma_th2d",4*nxbins,xbins[0],xbins[nxbins-1],(int)((tanbHigh-tanbLow)*10-1),tanbLow,tanbHigh);
+	TH2D *plus2sigma_th2d =new TH2D("plus2sigma_th2d","plus2sigma_th2d",4*nxbins,xbins[0],xbins[nxbins-1],(int)((tanbHigh-tanbLow)*10-1),tanbLow,tanbHigh);
+	TH2D *observed_th2d =new TH2D("observed_th2d","observed_th2d",4*nxbins,xbins[0],xbins[nxbins-1],(int)((tanbHigh-tanbLow)*10-1),tanbLow,tanbHigh);
+
+
+
+	if(HIG != ""){
+		std::cout << "NO LONGER SUPPORTED" << std::endl;
 	}
 	else{
-	  plane_minus2sigma->SetBinContent(idx, idy, graph_minus2sigma_tanb->Eval(plane_minus2sigma->GetXaxis()->GetBinCenter(idx), 0, "S"));
-	  plane_minus1sigma->SetBinContent(idx, idy, graph_minus1sigma_tanb->Eval(plane_minus1sigma->GetXaxis()->GetBinCenter(idx), 0, "S"));
-	  plane_expected   ->SetBinContent(idx, idy, graph_expected_tanb   ->Eval(plane_expected   ->GetXaxis()->GetBinCenter(idx), 0, "S"));
-	  plane_plus1sigma ->SetBinContent(idx, idy, graph_plus1sigma_tanb ->Eval(plane_plus1sigma ->GetXaxis()->GetBinCenter(idx), 0, "S"));
-	  plane_plus2sigma ->SetBinContent(idx, idy, graph_plus2sigma_tanb ->Eval(plane_plus2sigma ->GetXaxis()->GetBinCenter(idx), 0, "S"));
-	  plane_observed   ->SetBinContent(idx, idy, graph_observed_tanb   ->Eval(plane_observed   ->GetXaxis()->GetBinCenter(idx), 0, "S"));
+		//int ipoint_exp=0, ipoint_obs=0;
+		int kTwod=0;
+
+		for(unsigned int imass=0; imass<bins_.size(); ++imass){
+			// buffer mass value
+			float mass = bins_[imass];    
+			//control plots
+			TGraph* graph_minus2sigma = new TGraph();
+			TGraph* graph_minus1sigma = new TGraph();
+			TGraph* graph_expected = new TGraph();
+			TGraph* graph_plus1sigma = new TGraph();
+			TGraph* graph_plus2sigma = new TGraph();
+			TGraph* graph_observed = new TGraph();
+
+			TString fullpath = TString::Format("%s/%d/HypothesisTest.root", directory, (int)mass);
+			if (model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2")){ 
+				if(bins_[imass]!=(int)bins_[imass]) fullpath = TString::Format("%s/%0.1f/HypothesisTest.root", directory, bins_[imass]);
+				else fullpath = TString::Format("%s/%d/HypothesisTest.root",directory,(int)mass);
+			}
+			std::cout << "open file: " << fullpath << std::endl;
+			TFile* file_ = TFile::Open(fullpath); if(!file_){ std::cout << "--> TFile is corrupt: skipping masspoint." << std::endl; continue; }
+			TTree* limit = (TTree*) file_->Get("tree"); if(!limit){ std::cout << "--> TTree is corrupt: skipping masspoint." << std::endl; continue; }
+			double tanb, exp, obs, plus1sigma, minus1sigma, plus2sigma, minus2sigma;
+			limit->SetBranchAddress("tanb", &tanb );  
+			limit->SetBranchAddress("minus2sigma", &minus2sigma);
+			limit->SetBranchAddress("minus1sigma", &minus1sigma);
+			limit->SetBranchAddress("expected", &exp);
+			limit->SetBranchAddress("plus1sigma", &plus1sigma); 
+			limit->SetBranchAddress("plus2sigma", &plus2sigma);  
+			limit->SetBranchAddress("observed", &obs);  
+			int nevent = limit->GetEntries();   
+			//Drawing variable tanb with no graphics option.
+			//variable tanb stored in array fV1 (see TTree::Draw)
+			limit->Draw("tanb","","goff");
+			Int_t *index = new Int_t[nevent];
+			//sort array containing tanb in decreasing order
+			//The array index contains the entry numbers in increasing order in respect to tanb
+			TMath::Sort(nevent,limit->GetV1(),index,false); //changed from true (=default) =decreasing order
+			int k=0; double xmax=0; double ymax=0; //stuff needed for fitting;
+			// loop to find the crosspoint between low and high exclusion (tanbLowHigh)_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), plane_observed   ->GetYaxis()->FindBin(tanb), obs/exclusion_);
+			for(int i=0; i<nevent; ++i){
+				limit->GetEntry(index[i]);
+				//filling control plots
+				graph_minus2sigma->SetPoint(k, tanb, minus2sigma/exclusion_);
+				graph_minus1sigma->SetPoint(k, tanb, minus1sigma/exclusion_);
+				graph_expected   ->SetPoint(k, tanb, exp/exclusion_);
+				graph_plus1sigma ->SetPoint(k, tanb, plus1sigma/exclusion_);
+				graph_plus2sigma ->SetPoint(k, tanb, plus2sigma/exclusion_);
+				graph_observed   ->SetPoint(k, tanb, obs/exclusion_);
+				k++;      
+				for(int j=0; j<graph_minus2sigma->GetN(); j++){ 
+					if(graph_minus2sigma->GetY()[j]>ymax && graph_minus2sigma->GetX()[j]>=1) {ymax=graph_minus2sigma->GetY()[j]; xmax=graph_minus2sigma->GetX()[j]; tanbLowHigh=xmax;} //tanb>=1 hardcoded to fix that point 	  
+				}
+
+				// Fill TH2D with calculated limit points
+				plane_minus2sigma->SetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), plane_minus2sigma->GetYaxis()->FindBin(tanb), minus2sigma/exclusion_);
+				plane_minus1sigma->SetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), plane_minus1sigma->GetYaxis()->FindBin(tanb), minus1sigma/exclusion_);
+				plane_expected   ->SetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), plane_expected   ->GetYaxis()->FindBin(tanb), exp/exclusion_);
+				plane_plus1sigma ->SetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), plane_plus1sigma ->GetYaxis()->FindBin(tanb), plus1sigma/exclusion_);
+				plane_plus2sigma ->SetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), plane_plus2sigma ->GetYaxis()->FindBin(tanb), plus2sigma/exclusion_);
+				plane_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), plane_observed   ->GetYaxis()->FindBin(tanb), obs/exclusion_);
+				if(graphInterpolate_){
+					graph_minus2sigma_2d->SetPoint(kTwod,mass,tanb,minus2sigma/exclusion_);
+					graph_minus1sigma_2d->SetPoint(kTwod,mass,tanb,minus1sigma/exclusion_);
+					graph_expected_2d->SetPoint(kTwod,mass,tanb,exp/exclusion_);
+					graph_plus1sigma_2d->SetPoint(kTwod,mass,tanb,plus1sigma/exclusion_);
+					graph_plus2sigma_2d->SetPoint(kTwod,mass,tanb,plus2sigma/exclusion_);
+					graph_observed_2d->SetPoint(kTwod,mass,tanb,obs/exclusion_);
+					kTwod++;
+				}
+			}	
+
+			//control plot plotting
+			CLsControlPlots(graph_minus2sigma, graph_minus1sigma, graph_expected, graph_plus1sigma, graph_plus2sigma, graph_observed, directory, mass, xmax, ymax, model);
+
+			//push back graphs and save mass for tex/txt output printing
+			v_graph_minus2sigma.push_back(graph_minus2sigma);
+			v_graph_minus1sigma.push_back(graph_minus1sigma);
+			v_graph_expected.push_back(graph_expected);
+			v_graph_plus1sigma.push_back(graph_plus1sigma);
+			v_graph_plus2sigma.push_back(graph_plus2sigma);
+			v_graph_observed.push_back(graph_observed);
+			masses[imass]=mass;
+
+			// Interpolation along the y-axis for filling everything in between
+			limit->GetEntry(index[0]);
+			float tbmin=tanb; 
+			limit->GetEntry(index[nevent-1]);
+			float tbmax=tanb; 
+			for(int idy=1; idy<plane_minus2sigma->GetNbinsY()+1; idy++){
+				if (plane_minus2sigma->GetYaxis()->GetBinCenter(idy) > tbmin && plane_minus2sigma->GetYaxis()->GetBinCenter(idy) < tbmax ){
+					if(linearFit_){
+						plane_minus2sigma->SetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), idy, graph_minus2sigma->Eval(plane_minus2sigma->GetYaxis()->GetBinCenter(idy)));
+						plane_minus1sigma->SetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), idy, graph_minus1sigma->Eval(plane_minus1sigma->GetYaxis()->GetBinCenter(idy)));
+						plane_expected   ->SetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), idy, graph_expected   ->Eval(plane_expected   ->GetYaxis()->GetBinCenter(idy)));
+						plane_plus1sigma ->SetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), idy, graph_plus1sigma ->Eval(plane_plus1sigma ->GetYaxis()->GetBinCenter(idy)));
+						plane_plus2sigma ->SetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), idy, graph_plus2sigma ->Eval(plane_plus2sigma ->GetYaxis()->GetBinCenter(idy)));
+						plane_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), idy, graph_observed   ->Eval(plane_observed   ->GetYaxis()->GetBinCenter(idy)));
+					}
+					else{
+						plane_minus2sigma->SetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), idy, graph_minus2sigma->Eval(plane_minus2sigma->GetYaxis()->GetBinCenter(idy), 0, "S"));
+						plane_minus1sigma->SetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), idy, graph_minus1sigma->Eval(plane_minus1sigma->GetYaxis()->GetBinCenter(idy), 0, "S"));
+						plane_expected   ->SetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), idy, graph_expected   ->Eval(plane_expected   ->GetYaxis()->GetBinCenter(idy), 0, "S"));
+						plane_plus1sigma ->SetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), idy, graph_plus1sigma ->Eval(plane_plus1sigma ->GetYaxis()->GetBinCenter(idy), 0, "S"));
+						plane_plus2sigma ->SetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), idy, graph_plus2sigma ->Eval(plane_plus2sigma ->GetYaxis()->GetBinCenter(idy), 0, "S"));
+						plane_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), idy, graph_observed   ->Eval(plane_observed   ->GetYaxis()->GetBinCenter(idy), 0, "S"));
+					}
+				}
+				else if(plane_minus2sigma->GetYaxis()->GetBinCenter(idy) < tbmin){
+					plane_minus2sigma->SetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), idy, graph_minus2sigma->GetY()[0]);
+					plane_minus1sigma->SetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), idy, graph_minus1sigma->GetY()[0]);
+					plane_expected   ->SetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), idy, graph_expected   ->GetY()[0]);
+					plane_plus1sigma ->SetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), idy, graph_plus1sigma ->GetY()[0]);
+					plane_plus2sigma ->SetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), idy, graph_plus2sigma ->GetY()[0]);
+					plane_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), idy, graph_observed   ->GetY()[0]);
+				}
+				else if(plane_minus2sigma->GetYaxis()->GetBinCenter(idy) > tbmax){
+					plane_minus2sigma->SetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), idy, graph_minus2sigma->GetY()[graph_minus2sigma->GetN()-1]);
+					plane_minus1sigma->SetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), idy, graph_minus1sigma->GetY()[graph_minus1sigma->GetN()-1]);
+					plane_expected   ->SetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), idy, graph_expected   ->GetY()[graph_expected   ->GetN()-1]);
+					plane_plus1sigma ->SetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), idy, graph_plus1sigma ->GetY()[graph_plus1sigma ->GetN()-1]);
+					plane_plus2sigma ->SetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), idy, graph_plus2sigma ->GetY()[graph_plus2sigma ->GetN()-1]);
+					plane_observed   ->SetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), idy, graph_observed   ->GetY()[graph_observed   ->GetN()-1]);
+				}
+			}
+		}
+	}	
+
+	// Interpolation along the x-axis for filling everything in between
+	for(int idy=0; idy<plane_minus2sigma->GetNbinsY()+1; idy++){
+		TGraph* graph_minus2sigma_tanb = new TGraph();
+		TGraph* graph_minus1sigma_tanb = new TGraph();
+		TGraph* graph_expected_tanb = new TGraph();
+		TGraph* graph_plus1sigma_tanb = new TGraph();
+		TGraph* graph_plus2sigma_tanb = new TGraph();
+		TGraph* graph_observed_tanb = new TGraph();
+		for(unsigned int imass=0; imass<bins_.size(); ++imass){
+			// buffer mass value
+			float mass = bins_[imass];
+			graph_minus2sigma_tanb->SetPoint(imass, mass, plane_minus2sigma->GetBinContent(plane_minus2sigma->GetXaxis()->FindBin(mass), idy));
+			graph_minus1sigma_tanb->SetPoint(imass, mass, plane_minus1sigma->GetBinContent(plane_minus1sigma->GetXaxis()->FindBin(mass), idy));
+			graph_expected_tanb   ->SetPoint(imass, mass, plane_expected   ->GetBinContent(plane_expected   ->GetXaxis()->FindBin(mass), idy));
+			graph_plus1sigma_tanb ->SetPoint(imass, mass, plane_plus1sigma ->GetBinContent(plane_plus1sigma ->GetXaxis()->FindBin(mass), idy));
+			graph_plus2sigma_tanb ->SetPoint(imass, mass, plane_plus2sigma ->GetBinContent(plane_plus2sigma ->GetXaxis()->FindBin(mass), idy));
+			graph_observed_tanb   ->SetPoint(imass, mass, plane_observed   ->GetBinContent(plane_observed   ->GetXaxis()->FindBin(mass), idy));
+		}
+		for(int idx=0; idx<plane_minus2sigma->GetNbinsX()+1; idx++)
+		{
+			if(linearFit_){
+				plane_minus2sigma->SetBinContent(idx, idy, graph_minus2sigma_tanb->Eval(plane_minus2sigma->GetXaxis()->GetBinCenter(idx)));
+				plane_minus1sigma->SetBinContent(idx, idy, graph_minus1sigma_tanb->Eval(plane_minus1sigma->GetXaxis()->GetBinCenter(idx)));
+				plane_expected   ->SetBinContent(idx, idy, graph_expected_tanb   ->Eval(plane_expected   ->GetXaxis()->GetBinCenter(idx)));
+				plane_plus1sigma ->SetBinContent(idx, idy, graph_plus1sigma_tanb ->Eval(plane_plus1sigma ->GetXaxis()->GetBinCenter(idx)));
+				plane_plus2sigma ->SetBinContent(idx, idy, graph_plus2sigma_tanb ->Eval(plane_plus2sigma ->GetXaxis()->GetBinCenter(idx)));
+				plane_observed   ->SetBinContent(idx, idy, graph_observed_tanb   ->Eval(plane_observed   ->GetXaxis()->GetBinCenter(idx)));
+			}
+			else{
+				plane_minus2sigma->SetBinContent(idx, idy, graph_minus2sigma_tanb->Eval(plane_minus2sigma->GetXaxis()->GetBinCenter(idx), 0, "S"));
+				plane_minus1sigma->SetBinContent(idx, idy, graph_minus1sigma_tanb->Eval(plane_minus1sigma->GetXaxis()->GetBinCenter(idx), 0, "S"));
+				plane_expected   ->SetBinContent(idx, idy, graph_expected_tanb   ->Eval(plane_expected   ->GetXaxis()->GetBinCenter(idx), 0, "S"));
+				plane_plus1sigma ->SetBinContent(idx, idy, graph_plus1sigma_tanb ->Eval(plane_plus1sigma ->GetXaxis()->GetBinCenter(idx), 0, "S"));
+				plane_plus2sigma ->SetBinContent(idx, idy, graph_plus2sigma_tanb ->Eval(plane_plus2sigma ->GetXaxis()->GetBinCenter(idx), 0, "S"));
+				plane_observed   ->SetBinContent(idx, idy, graph_observed_tanb   ->Eval(plane_observed   ->GetXaxis()->GetBinCenter(idx), 0, "S"));
+			}
+		}
 	}
-      }
-  }
-//   plane_minus2sigma->Smooth(1, "k5b");
-//   plane_minus1sigma->Smooth(1, "k5b");
-//   plane_expected   ->Smooth(1, "k5b");
-//   plane_plus1sigma ->Smooth(1, "k5b");
-//   plane_plus2sigma ->Smooth(1, "k5b");
-//   plane_observed   ->Smooth(11, "k5b")
 
-  // Grabbing contours
-  std::vector<TGraph*> gr_minus2sigma;
-  std::vector<TGraph*> gr_minus1sigma;
-  std::vector<TGraph*> gr_expected;
-  std::vector<TGraph*> gr_plus1sigma;
-  std::vector<TGraph*> gr_plus2sigma;
-  std::vector<TGraph*> gr_observed;
-  std::vector<TGraph*> gr_injected;
-  gr_injected.push_back(0);
-  
-  int n_m2s, n_m1s, n_exp, n_p1s, n_p2s, n_obs;
-  TIter iterm2s((TList *)contourFromTH2(plane_minus2sigma, 1.0, 20, false));
-  STestFunctor m2s = std::for_each( iterm2s.Begin(), TIter::End(), STestFunctor() );
-  n_m2s=m2s.sum; 
-  TIter iterm1s((TList *)contourFromTH2(plane_minus1sigma, 1.0, 20, false));
-  STestFunctor m1s = std::for_each( iterm1s.Begin(), TIter::End(), STestFunctor() );
-  n_m1s=m1s.sum; 
-  TIter iterexp((TList *)contourFromTH2(plane_expected, 1.0, 20, false));
-  STestFunctor exp = std::for_each( iterexp.Begin(), TIter::End(), STestFunctor() );
-  n_exp=exp.sum; 
-  TIter iterp1s((TList *)contourFromTH2(plane_plus1sigma, 1.0, 20, false));
-  STestFunctor p1s = std::for_each( iterp1s.Begin(), TIter::End(), STestFunctor() );
-  n_p1s=p1s.sum; 
-  TIter iterp2s((TList *)contourFromTH2(plane_plus2sigma, 1.0, 20, false));
-  STestFunctor p2s = std::for_each( iterp2s.Begin(), TIter::End(), STestFunctor() );
-  n_p2s=p2s.sum; 
-  TIter iterobs((TList *)contourFromTH2(plane_observed, 1.0, 20, false));
-  STestFunctor obs = std::for_each( iterobs.Begin(), TIter::End(), STestFunctor() );
-  n_obs=obs.sum; 
+	if(graphInterpolate_){
+		for(int i=0; i<expected_th2d->GetXaxis()->GetNbins();i++){
+			for(int j=0; j<expected_th2d->GetYaxis()->GetNbins();j++){
+				minus2sigma_th2d->SetBinContent(i,j,graph_minus2sigma_2d->Interpolate(minus2sigma_th2d->GetXaxis()->GetBinCenter(i),minus2sigma_th2d->GetYaxis()->GetBinCenter(j)));
+				minus1sigma_th2d->SetBinContent(i,j,graph_minus1sigma_2d->Interpolate(minus1sigma_th2d->GetXaxis()->GetBinCenter(i),minus1sigma_th2d->GetYaxis()->GetBinCenter(j)));
+				expected_th2d->SetBinContent(i,j,graph_expected_2d->Interpolate(expected_th2d->GetXaxis()->GetBinCenter(i),expected_th2d->GetYaxis()->GetBinCenter(j)));
+				plus1sigma_th2d->SetBinContent(i,j,graph_plus1sigma_2d->Interpolate(plus1sigma_th2d->GetXaxis()->GetBinCenter(i),plus1sigma_th2d->GetYaxis()->GetBinCenter(j)));
+				plus2sigma_th2d->SetBinContent(i,j,graph_plus2sigma_2d->Interpolate(plus2sigma_th2d->GetXaxis()->GetBinCenter(i),plus2sigma_th2d->GetYaxis()->GetBinCenter(j)));
+				observed_th2d->SetBinContent(i,j,graph_observed_2d->Interpolate(observed_th2d->GetXaxis()->GetBinCenter(i),observed_th2d->GetYaxis()->GetBinCenter(j)));
+			}
 
-  for(int i=0; i<n_m2s; i++) {gr_minus2sigma.push_back((TGraph *)((TList *)contourFromTH2(plane_minus2sigma, 1.0, 20, false))->At(i));}
-  for(int i=0; i<n_m1s; i++) {gr_minus1sigma.push_back((TGraph *)((TList *)contourFromTH2(plane_minus1sigma, 1.0, 20, false))->At(i));}
-  for(int i=0; i<n_exp; i++) {gr_expected.push_back(   (TGraph *)((TList *)contourFromTH2(plane_expected,    1.0, 20, false))->At(i));}
-  for(int i=0; i<n_p1s; i++) {gr_plus1sigma.push_back( (TGraph *)((TList *)contourFromTH2(plane_plus1sigma,  1.0, 20, false))->At(i));}
-  for(int i=0; i<n_p2s; i++) {gr_plus2sigma.push_back( (TGraph *)((TList *)contourFromTH2(plane_plus2sigma,  1.0, 20, false))->At(i));}
-  for(int i=0; i<n_obs; i++) {gr_observed.push_back(   (TGraph *)((TList *)contourFromTH2(plane_observed,    1.0, 20, false))->At(i));}
-  //std::cout<< gr_minus2sigma.size() << " " << gr_minus1sigma.size() << " " << gr_expected.size() << " " << gr_plus1sigma.size() << " " << gr_plus2sigma.size() << " " << gr_observed.size() << std::endl;
-  
-  //gr_expected[1]->SaveAs("exp_graph.root");
-  // create plots for additional comparisons
-  std::map<std::string, TGraph*> comparisons; TGraph* comp=0;
-  if(arXiv_1211_6956_){ comp = new TGraph(), arXiv_1211_6956 (comp); comp->SetName("arXiv_1211_6956" ); comparisons[std::string("ATLAS H#rightarrow#tau#tau (4.8/fb)")] = comp;}
-  if(arXiv_1204_2760_){ comp = new TGraph(); arXiv_1204_2760 (comp); comp->SetName("arXiv_1204_2760" ); comparisons[std::string("ATLAS H^{+} (4.6/fb)")               ] = comp;}
-  if(arXiv_1302_2892_){ comp = new TGraph(); arXiv_1302_2892 (comp); comp->SetName("arXiv_1302_2892" ); comparisons[std::string("CMS #phi#rightarrowb#bar{b}")        ] = comp;}
-  if(arXiv_1205_5736_){ comp = new TGraph(); arXiv_1205_5736 (comp); comp->SetName("arXiv_1205_5736" ); comparisons[std::string("CMS H^{+} (2/fb)")                   ] = comp;}
-  if(HIG_12_052_     ){ comp = new TGraph(); HIG_12_052_lower(comp); comp->SetName("HIG_12_052_lower"); comparisons[std::string("CMS H^{+} (2-4.9/fb)")               ] = comp;}
-  if(HIG_12_052_     ){ comp = new TGraph(); HIG_12_052_upper(comp); comp->SetName("HIG_12_052_upper"); comparisons[std::string("EMPTY")                              ] = comp;}
+		}
 
-  // setup contratins from Higgs mass
-  std::map<double,TGraphAsymmErrors*> higgsBands;
-  std::map<double,std::vector<TGraph*>> higgsBandsContour;
-  if(higgs125_&&model!=TString::Format("low-tb-high")){
-    higgsBands[3] = higgsConstraint(plane_expected, 125., 3., model, "h");
-//   higgsBands[2] = higgsConstraint(plane_expected, 125., 3., model, "h",false);
-//   higgsBands[3] = higgsConstraint(plane_expected, 305., 45., model, "H",true);
-    //higgsBands[1] = higgsConstraint(plane_expected, 125., 1., model);
-    //for(unsigned int deltaM=0; deltaM<3; ++deltaM){
-    //  higgsBands[3-deltaM] = higgsConstraint(plane_expected, 125., 4-deltaM, model);
-    //}
-  }  
-else if(higgs125_&&model==TString::Format("low-tb-high")){
- std::vector<std::vector<TGraph*>> higgsBandVec = higgsConstraintLowTb(plane_expected,125.,3.,305.,45.,model);
-   if(!azh_){
-    for(unsigned int ii=0;ii<higgsBandVec.size();ii++){
-      higgsBandsContour[ii]=higgsBandVec.at(ii);
-     }
-    }
-   else if(azh_){
-    higgsBandsContour[0]=higgsBandVec.at(1);
-   }
-  }
+	}
 
-  
-  // do the plotting
-  plottingTanb(canv, plane_expected, gr_minus2sigma, gr_minus1sigma, gr_expected, gr_plus1sigma, gr_plus2sigma, gr_observed, gr_injected, higgsBands,higgsBandsContour, comparisons, xaxis_, yaxis_, theory_, min_, max_, log_, transparent_, expectedOnly_, MSSMvsSM_, HIG, Brazilian_,azh_); 
-  /// setup the CMS Preliminary
-  //CMSPrelim(dataset_.c_str(), "", 0.145, 0.835);
-  //TPaveText* cmsprel = new TPaveText(0.145, 0.835+0.06, 0.145+0.30, 0.835+0.16, "NDC");
-  TPaveText* cmsprel = new TPaveText(0.135, 0.835+0.06, 0.145+0.30, 0.835+0.16, "NDC"); // for "unpublished" in header
-  cmsprel->SetBorderSize(   0 );
-  cmsprel->SetFillStyle(    0 );
-  cmsprel->SetTextAlign(   12 );
-  cmsprel->SetTextSize ( 0.03 );
-  cmsprel->SetTextColor(    1 );
-  cmsprel->SetTextFont (   62 );
-  cmsprel->AddText(dataset_.c_str());
-  cmsprel->Draw();
+	//   plane_minus2sigma->Smooth(1, "k5b");
+	//   plane_minus1sigma->Smooth(1, "k5b");
+	//   plane_expected   ->Smooth(1, "k5b");
+	//   plane_plus1sigma ->Smooth(1, "k5b");
+	//   plane_plus2sigma ->Smooth(1, "k5b");
+	//   plane_observed   ->Smooth(11, "k5b")
 
-  // write results to files
-  if(png_){
-    canv.Print(std::string(output_).append("_").append(extralabel_).append(label_).append(".png").c_str());
-  }
-  if(pdf_){
-    canv.Print(std::string(output_).append("_").append(extralabel_).append(label_).append(".pdf").c_str());
-    canv.Print(std::string(output_).append("_").append(extralabel_).append(label_).append(".eps").c_str());
-  }
-  // write txt and tex files
-  if(txt_){
-    print(std::string(output_).append("_").append(extralabel_).append(label_).c_str(), v_graph_minus2sigma, v_graph_minus1sigma, v_graph_expected, v_graph_plus1sigma, v_graph_plus2sigma, v_graph_observed, tanbLow, tanbHigh, masses, "txt");
-    print(std::string(output_).append("_").append(extralabel_).append(label_).c_str(), v_graph_minus2sigma, v_graph_minus1sigma, v_graph_expected, v_graph_plus1sigma, v_graph_plus2sigma, v_graph_observed, tanbLow, tanbHigh, masses, "tex");
-  }
-  if(root_){
-    TFile* output = new TFile(std::string(output_).append("_").append(extralabel_).append(label_).append(".root").c_str(), "update");
-    if(!output->cd(output_.c_str())){
-      output->mkdir(output_.c_str());
-      output->cd(output_.c_str());
-    }
-    plane_expected->Write("plane_expected"); 
-    for(unsigned int i=0; i<gr_observed.size(); i++){
-      gr_observed[i]   ->Write(TString::Format("gr_observed_%d", i)  ); 
-    }
-    for(unsigned int i=0; i<gr_expected.size(); i++){
-      gr_expected[i]   ->Write(TString::Format("gr_expected_%d", i)    );
-    }
-    for(unsigned int i=0; i<gr_minus2sigma.size(); i++){
-      gr_minus2sigma[i]->Write(TString::Format("gr_minus2sigma_%d", i)    );
-    }
-    for(unsigned int i=0; i<gr_minus1sigma.size(); i++){
-      gr_minus1sigma[i]->Write(TString::Format("gr_minus1sigma_%d", i)    ); 
-    }
-    for(unsigned int i=0; i<gr_plus1sigma.size(); i++){
-      gr_plus1sigma[i] ->Write(TString::Format("gr_plus1sigma_%d", i)     );
-    }
-    for(unsigned int i=0; i<gr_plus2sigma.size(); i++){
-      gr_plus2sigma[i] ->Write(TString::Format("gr_plus2sigma_%d", i)     );
-    }
-    output->Close();
-  }
-  // save exclusion in each mass directory - needed for smart scan!
-  for(unsigned int imass=0; imass<bins_.size(); ++imass){
-    //std::cout << TString::Format("%s/%d/exclusion", directory, (int)bins_[imass]) << std::endl;
-    print(TString::Format("%s/%d/exclusion", directory, (int)bins_[imass]), v_graph_minus2sigma, v_graph_minus1sigma, v_graph_expected, v_graph_plus1sigma, v_graph_plus2sigma, v_graph_observed, tanbLow, tanbHigh, masses, "dat");
-  }
-  return;
+	// Grabbing contours
+
+
+	std::vector<TGraph*> gr_minus2sigma;
+	std::vector<TGraph*> gr_minus1sigma;
+	std::vector<TGraph*> gr_expected;
+	std::vector<TGraph*> gr_plus1sigma;
+	std::vector<TGraph*> gr_plus2sigma;
+	std::vector<TGraph*> gr_observed;
+	std::vector<TGraph*> gr_injected;
+	gr_injected.push_back(0);
+
+	int n_m2s, n_m1s, n_exp, n_p1s, n_p2s, n_obs;
+	if(graphInterpolate_){
+		std::cout<<"AAA"<<std::endl;
+		TIter iterm2s((TList *)contourFromTH2(minus2sigma_th2d, 1.0, 20, false,5));
+		STestFunctor m2s = std::for_each( iterm2s.Begin(), TIter::End(), STestFunctor() );
+		n_m2s=m2s.sum; 
+		TIter iterm1s((TList *)contourFromTH2(minus1sigma_th2d, 1.0, 20, false,5));
+		STestFunctor m1s = std::for_each( iterm1s.Begin(), TIter::End(), STestFunctor() );
+		n_m1s=m1s.sum; 
+		TIter iterexp((TList *)contourFromTH2(expected_th2d, 1.0, 20, false,5));
+		STestFunctor exp = std::for_each( iterexp.Begin(), TIter::End(), STestFunctor() );
+		n_exp=exp.sum; 
+		TIter iterp1s((TList *)contourFromTH2(plus1sigma_th2d, 1.0, 20, false,5));
+		STestFunctor p1s = std::for_each( iterp1s.Begin(), TIter::End(), STestFunctor() );
+		n_p1s=p1s.sum; 
+		TIter iterp2s((TList *)contourFromTH2(plus2sigma_th2d, 1.0, 20, false,5));
+		STestFunctor p2s = std::for_each( iterp2s.Begin(), TIter::End(), STestFunctor() );
+		n_p2s=p2s.sum; 
+		TIter iterobs((TList *)contourFromTH2(observed_th2d, 1.0, 20, false,5));
+		STestFunctor obs = std::for_each( iterobs.Begin(), TIter::End(), STestFunctor() );
+		n_obs=obs.sum; 
+		for(int i=0; i<n_m2s; i++) {gr_minus2sigma.push_back((TGraph *)((TList *)contourFromTH2(minus2sigma_th2d, 1.0, 20, false,5))->At(i));}
+		for(int i=0; i<n_m1s; i++) {gr_minus1sigma.push_back((TGraph *)((TList *)contourFromTH2(minus1sigma_th2d, 1.0, 20, false,5))->At(i));}
+		for(int i=0; i<n_exp; i++) {gr_expected.push_back(   (TGraph *)((TList *)contourFromTH2(expected_th2d,    1.0, 20, false,5))->At(i));}
+		for(int i=0; i<n_p1s; i++) {gr_plus1sigma.push_back( (TGraph *)((TList *)contourFromTH2(plus1sigma_th2d,  1.0, 20, false,5))->At(i));}
+		for(int i=0; i<n_p2s; i++) {gr_plus2sigma.push_back( (TGraph *)((TList *)contourFromTH2(plus2sigma_th2d,  1.0, 20, false,5))->At(i));}
+		for(int i=0; i<n_obs; i++) {gr_observed.push_back(   (TGraph *)((TList *)contourFromTH2(observed_th2d,    1.0, 20, false,5))->At(i));}
+
+	}
+	else{
+		TIter iterm2s((TList *)contourFromTH2(plane_minus2sigma, 1.0, 20, false,1));
+		STestFunctor m2s = std::for_each( iterm2s.Begin(), TIter::End(), STestFunctor() );
+		n_m2s=m2s.sum; 
+		TIter iterm1s((TList *)contourFromTH2(plane_minus1sigma, 1.0, 20, false,1));
+		STestFunctor m1s = std::for_each( iterm1s.Begin(), TIter::End(), STestFunctor() );
+		n_m1s=m1s.sum; 
+		TIter iterexp((TList *)contourFromTH2(plane_expected, 1.0, 20, false,1));
+		STestFunctor exp = std::for_each( iterexp.Begin(), TIter::End(), STestFunctor() );
+		n_exp=exp.sum; 
+		TIter iterp1s((TList *)contourFromTH2(plane_plus1sigma, 1.0, 20, false,1));
+		STestFunctor p1s = std::for_each( iterp1s.Begin(), TIter::End(), STestFunctor() );
+		n_p1s=p1s.sum; 
+		TIter iterp2s((TList *)contourFromTH2(plane_plus2sigma, 1.0, 20, false,1));
+		STestFunctor p2s = std::for_each( iterp2s.Begin(), TIter::End(), STestFunctor() );
+		n_p2s=p2s.sum; 
+		TIter iterobs((TList *)contourFromTH2(plane_observed, 1.0, 20, false,1));
+		STestFunctor obs = std::for_each( iterobs.Begin(), TIter::End(), STestFunctor() );
+		n_obs=obs.sum; 
+		for(int i=0; i<n_m2s; i++) {gr_minus2sigma.push_back((TGraph *)((TList *)contourFromTH2(plane_minus2sigma, 1.0, 20, false,1))->At(i));}
+		for(int i=0; i<n_m1s; i++) {gr_minus1sigma.push_back((TGraph *)((TList *)contourFromTH2(plane_minus1sigma, 1.0, 20, false,1))->At(i));}
+		for(int i=0; i<n_exp; i++) {gr_expected.push_back(   (TGraph *)((TList *)contourFromTH2(plane_expected,    1.0, 20, false,1))->At(i));}
+		for(int i=0; i<n_p1s; i++) {gr_plus1sigma.push_back( (TGraph *)((TList *)contourFromTH2(plane_plus1sigma,  1.0, 20, false,1))->At(i));}
+		for(int i=0; i<n_p2s; i++) {gr_plus2sigma.push_back( (TGraph *)((TList *)contourFromTH2(plane_plus2sigma,  1.0, 20, false,1))->At(i));}
+		for(int i=0; i<n_obs; i++) {gr_observed.push_back(   (TGraph *)((TList *)contourFromTH2(plane_observed,    1.0, 20, false,1))->At(i));}
+	}
+
+	//std::cout<< gr_minus2sigma.size() << " " << gr_minus1sigma.size() << " " << gr_expected.size() << " " << gr_plus1sigma.size() << " " << gr_plus2sigma.size() << " " << gr_observed.size() << std::endl;
+
+	//gr_expected[1]->SaveAs("exp_graph.root");
+	// create plots for additional comparisons
+	std::map<std::string, TGraph*> comparisons; TGraph* comp=0;
+	if(arXiv_1211_6956_){ comp = new TGraph(), arXiv_1211_6956 (comp); comp->SetName("arXiv_1211_6956" ); comparisons[std::string("ATLAS H#rightarrow#tau#tau (4.8/fb)")] = comp;}
+	if(arXiv_1204_2760_){ comp = new TGraph(); arXiv_1204_2760 (comp); comp->SetName("arXiv_1204_2760" ); comparisons[std::string("ATLAS H^{+} (4.6/fb)")               ] = comp;}
+	if(arXiv_1302_2892_){ comp = new TGraph(); arXiv_1302_2892 (comp); comp->SetName("arXiv_1302_2892" ); comparisons[std::string("CMS #phi#rightarrowb#bar{b}")        ] = comp;}
+	if(arXiv_1205_5736_){ comp = new TGraph(); arXiv_1205_5736 (comp); comp->SetName("arXiv_1205_5736" ); comparisons[std::string("CMS H^{+} (2/fb)")                   ] = comp;}
+	if(HIG_12_052_     ){ comp = new TGraph(); HIG_12_052_lower(comp); comp->SetName("HIG_12_052_lower"); comparisons[std::string("CMS H^{+} (2-4.9/fb)")               ] = comp;}
+	if(HIG_12_052_     ){ comp = new TGraph(); HIG_12_052_upper(comp); comp->SetName("HIG_12_052_upper"); comparisons[std::string("EMPTY")                              ] = comp;}
+
+	// setup contratins from Higgs mass
+	std::map<double,TGraphAsymmErrors*> higgsBands;
+	std::map<double,std::vector<TGraph*>> higgsBandsContour;
+	if(higgs125_&&model!=TString::Format("low-tb-high")){
+		higgsBands[3] = higgsConstraint(plane_expected, 125., 3., model, "h");
+		//   higgsBands[2] = higgsConstraint(plane_expected, 125., 3., model, "h",false);
+		//   higgsBands[3] = higgsConstraint(plane_expected, 305., 45., model, "H",true);
+		//higgsBands[1] = higgsConstraint(plane_expected, 125., 1., model);
+		//for(unsigned int deltaM=0; deltaM<3; ++deltaM){
+		//  higgsBands[3-deltaM] = higgsConstraint(plane_expected, 125., 4-deltaM, model);
+		//}
+	}  
+	else if(higgs125_&&model==TString::Format("low-tb-high")){
+		std::vector<std::vector<TGraph*>> higgsBandVec = higgsConstraintLowTb(plane_expected,125.,3.,305.,45.,model);
+		if(!azh_){
+			for(unsigned int ii=0;ii<higgsBandVec.size();ii++){
+				higgsBandsContour[ii]=higgsBandVec.at(ii);
+			}
+		}
+		else if(azh_){
+			higgsBandsContour[0]=higgsBandVec.at(1);
+		}
+	}
+
+
+	// do the plotting
+	plottingTanb(canv, plane_expected, gr_minus2sigma, gr_minus1sigma, gr_expected, gr_plus1sigma, gr_plus2sigma, gr_observed, gr_injected, higgsBands,higgsBandsContour, comparisons, xaxis_, yaxis_, theory_, min_, max_, log_, transparent_, expectedOnly_, MSSMvsSM_, HIG, Brazilian_,azh_); 
+	/// setup the CMS Preliminary
+	//CMSPrelim(dataset_.c_str(), "", 0.145, 0.835);
+	//TPaveText* cmsprel = new TPaveText(0.145, 0.835+0.06, 0.145+0.30, 0.835+0.16, "NDC");
+	TPaveText* cmsprel = new TPaveText(0.135, 0.835+0.06, 0.145+0.30, 0.835+0.16, "NDC"); // for "unpublished" in header
+	cmsprel->SetBorderSize(   0 );
+	cmsprel->SetFillStyle(    0 );
+	cmsprel->SetTextAlign(   12 );
+	cmsprel->SetTextSize ( 0.03 );
+	cmsprel->SetTextColor(    1 );
+	cmsprel->SetTextFont (   62 );
+	cmsprel->AddText(dataset_.c_str());
+	cmsprel->Draw();
+
+	// write results to files
+	if(png_){
+		canv.Print(std::string(output_).append("_").append(extralabel_).append(label_).append(".png").c_str());
+	}
+	if(pdf_){
+		canv.Print(std::string(output_).append("_").append(extralabel_).append(label_).append(".pdf").c_str());
+		canv.Print(std::string(output_).append("_").append(extralabel_).append(label_).append(".eps").c_str());
+	}
+	// write txt and tex files
+	if(txt_){
+		print(std::string(output_).append("_").append(extralabel_).append(label_).c_str(), v_graph_minus2sigma, v_graph_minus1sigma, v_graph_expected, v_graph_plus1sigma, v_graph_plus2sigma, v_graph_observed, tanbLow, tanbHigh, masses, "txt");
+		print(std::string(output_).append("_").append(extralabel_).append(label_).c_str(), v_graph_minus2sigma, v_graph_minus1sigma, v_graph_expected, v_graph_plus1sigma, v_graph_plus2sigma, v_graph_observed, tanbLow, tanbHigh, masses, "tex");
+	}
+	if(root_){
+		TFile* output = new TFile(std::string(output_).append("_").append(extralabel_).append(label_).append(".root").c_str(), "update");
+		if(!output->cd(output_.c_str())){
+			output->mkdir(output_.c_str());
+			output->cd(output_.c_str());
+		}
+		plane_expected->Write("plane_expected"); 
+		for(unsigned int i=0; i<gr_observed.size(); i++){
+			gr_observed[i]   ->Write(TString::Format("gr_observed_%d", i)  ); 
+		}
+		for(unsigned int i=0; i<gr_expected.size(); i++){
+			gr_expected[i]   ->Write(TString::Format("gr_expected_%d", i)    );
+		}
+		for(unsigned int i=0; i<gr_minus2sigma.size(); i++){
+			gr_minus2sigma[i]->Write(TString::Format("gr_minus2sigma_%d", i)    );
+		}
+		for(unsigned int i=0; i<gr_minus1sigma.size(); i++){
+			gr_minus1sigma[i]->Write(TString::Format("gr_minus1sigma_%d", i)    ); 
+		}
+		for(unsigned int i=0; i<gr_plus1sigma.size(); i++){
+			gr_plus1sigma[i] ->Write(TString::Format("gr_plus1sigma_%d", i)     );
+		}
+		for(unsigned int i=0; i<gr_plus2sigma.size(); i++){
+			gr_plus2sigma[i] ->Write(TString::Format("gr_plus2sigma_%d", i)     );
+		}
+		output->Close();
+	}
+	// save exclusion in each mass directory - needed for smart scan!
+	for(unsigned int imass=0; imass<bins_.size(); ++imass){
+		//std::cout << TString::Format("%s/%d/exclusion", directory, (int)bins_[imass]) << std::endl;
+		print(TString::Format("%s/%d/exclusion", directory, (int)bins_[imass]), v_graph_minus2sigma, v_graph_minus1sigma, v_graph_expected, v_graph_plus1sigma, v_graph_plus2sigma, v_graph_observed, tanbLow, tanbHigh, masses, "dat");
+	}
+	return;
 }
 
 
@@ -414,163 +498,169 @@ else if(higgs125_&&model==TString::Format("low-tb-high")){
 
 
 void CLsControlPlots(TGraph* graph_minus2sigma, TGraph* graph_minus1sigma, TGraph* graph_expected, TGraph* graph_plus1sigma, TGraph* graph_plus2sigma, TGraph* graph_observed, const char* directory, float mass, int xmax, int ymax, const char* model){
-//control plots showing the CLs value over tanb for each mass
-    //minus2sigma
-    TCanvas* canv_minus2sigma = new TCanvas();
-    if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_minus2sigma = new TCanvas(TString::Format("tanb-CLs_025_%0.1f", mass), "", 600, 600);
-    else canv_minus2sigma = new TCanvas(TString::Format("tanb-CLs_025_%d", (int)mass), "", 600, 600);
-    canv_minus2sigma->cd();
-    canv_minus2sigma->SetGridx(1);
-    canv_minus2sigma->SetGridy(1);
-    graph_minus2sigma->GetXaxis()->SetTitle("tan#beta");
-    graph_minus2sigma->GetXaxis()->SetLabelFont(62);
-    graph_minus2sigma->GetXaxis()->SetTitleFont(62);
-    graph_minus2sigma->GetXaxis()->SetTitleColor(1);
-    graph_minus2sigma->GetXaxis()->SetTitleOffset(1.05);
-    graph_minus2sigma->GetYaxis()->SetTitle("CL_{s}");
-    graph_minus2sigma->GetYaxis()->SetLabelFont(62);
-    graph_minus2sigma->GetYaxis()->SetTitleFont(62);
-    graph_minus2sigma->GetYaxis()->SetTitleOffset(1.05);
-    graph_minus2sigma->GetYaxis()->SetLabelSize(0.03);
-    graph_minus2sigma->SetMarkerStyle(20);
-    graph_minus2sigma->SetMarkerSize(1.3);
-    ymax=0; ymax=0;
-    for(int j=0; j<graph_minus2sigma->GetN(); j++){ 
-      if(graph_minus2sigma->GetY()[j]>ymax) {ymax=graph_minus2sigma->GetY()[j]; xmax=graph_minus2sigma->GetX()[j];}
-    }
-    graph_minus2sigma->Draw("AP");
-    if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_minus2sigma->Print(TString::Format("%s/%0.1f/tanb-CLs_025_%0.1f.png", directory, mass, mass));
-    else canv_minus2sigma->Print(TString::Format("%s/%d/tanb-CLs_025_%d.png", directory, (int)mass, (int)mass));
-    //minus1sigma
-    TCanvas* canv_minus1sigma = new TCanvas();
-    if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_minus1sigma = new TCanvas(TString::Format("tanb-CLs_160_%0.1f", mass), "", 600, 600);
-    else canv_minus1sigma = new TCanvas(TString::Format("tanb-CLs_160_%d", (int)mass), "", 600, 600);
-    canv_minus1sigma->cd();
-    canv_minus1sigma->SetGridx(1);
-    canv_minus1sigma->SetGridy(1);
-    graph_minus1sigma->GetXaxis()->SetTitle("tan#beta");
-    graph_minus1sigma->GetXaxis()->SetLabelFont(62);
-    graph_minus1sigma->GetXaxis()->SetTitleFont(62);
-    graph_minus1sigma->GetXaxis()->SetTitleColor(1);
-    graph_minus1sigma->GetXaxis()->SetTitleOffset(1.05);
-    graph_minus1sigma->GetYaxis()->SetTitle("CL_{s}");
-    graph_minus1sigma->GetYaxis()->SetLabelFont(62);
-    graph_minus1sigma->GetYaxis()->SetTitleFont(62);
-    graph_minus1sigma->GetYaxis()->SetTitleOffset(1.05);
-    graph_minus1sigma->GetYaxis()->SetLabelSize(0.03);
-    graph_minus1sigma->SetMarkerStyle(20);
-    graph_minus1sigma->SetMarkerSize(1.3);
-    ymax=0; ymax=0;
-    for(int j=0; j<graph_minus1sigma->GetN(); j++){ 
-      if(graph_minus1sigma->GetY()[j]>ymax) {ymax=graph_minus1sigma->GetY()[j]; xmax=graph_minus1sigma->GetX()[j];}
-    }
-    graph_minus1sigma->Draw("AP");
-    if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_minus1sigma->Print(TString::Format("%s/%0.1f/tanb-CLs_160_%0.1f.png", directory, mass, mass));
-    else canv_minus1sigma->Print(TString::Format("%s/%d/tanb-CLs_160_%d.png", directory, (int)mass, (int)mass));
-    //expected
-    TCanvas* canv_expected = new TCanvas();
-    if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_expected = new TCanvas(TString::Format("tanb-CLs_EXP_%0.1f", mass), "", 600, 600);
-    else canv_expected = new TCanvas(TString::Format("tanb-CLs_EXP_%d", (int)mass), "", 600, 600);
-    canv_expected->cd();
-    canv_expected->SetGridx(1);
-    canv_expected->SetGridy(1);
-    graph_expected->GetXaxis()->SetTitle("tan#beta");
-    graph_expected->GetXaxis()->SetLabelFont(62);
-    graph_expected->GetXaxis()->SetTitleFont(62);
-    graph_expected->GetXaxis()->SetTitleColor(1);
-    graph_expected->GetXaxis()->SetTitleOffset(1.05);
-    graph_expected->GetYaxis()->SetTitle("CL_{s}");
-    graph_expected->GetYaxis()->SetLabelFont(62);
-    graph_expected->GetYaxis()->SetTitleFont(62);
-    graph_expected->GetYaxis()->SetTitleOffset(1.05);
-    graph_expected->GetYaxis()->SetLabelSize(0.03);
-    graph_expected->SetMarkerStyle(20);
-    graph_expected->SetMarkerSize(1.3);
-    ymax=0; ymax=0;
-    for(int j=0; j<graph_expected->GetN(); j++){ 
-      if(graph_expected->GetY()[j]>ymax) {ymax=graph_expected->GetY()[j]; xmax=graph_expected->GetX()[j];}
-    }
-    graph_expected->Draw("AP");
-    if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_expected->Print(TString::Format("%s/%0.1f/tanb-CLs_EXP_%0.1f.png", directory, mass, mass));
-    else canv_expected->Print(TString::Format("%s/%d/tanb-CLs_EXP_%d.png", directory, (int)mass, (int)mass));
-    //plus1sigma
-    TCanvas* canv_plus1sigma = new TCanvas();
-    if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_plus1sigma = new TCanvas(TString::Format("tanb-CLs_860_%0.1f", mass), "", 600, 600);
-    else canv_plus1sigma = new TCanvas(TString::Format("tanb-CLs_860_%d", (int)mass), "", 600, 600);
-    canv_plus1sigma->cd();
-    canv_plus1sigma->SetGridx(1);
-    canv_plus1sigma->SetGridy(1);
-    graph_plus1sigma->GetXaxis()->SetTitle("tan#beta");
-    graph_plus1sigma->GetXaxis()->SetLabelFont(62);
-    graph_plus1sigma->GetXaxis()->SetTitleFont(62);
-    graph_plus1sigma->GetXaxis()->SetTitleColor(1);
-    graph_plus1sigma->GetXaxis()->SetTitleOffset(1.05);
-    graph_plus1sigma->GetYaxis()->SetTitle("CL_{s}");
-    graph_plus1sigma->GetYaxis()->SetLabelFont(62);
-    graph_plus1sigma->GetYaxis()->SetTitleFont(62);
-    graph_plus1sigma->GetYaxis()->SetTitleOffset(1.05);
-    graph_plus1sigma->GetYaxis()->SetLabelSize(0.03);
-    graph_plus1sigma->SetMarkerStyle(20);
-    graph_plus1sigma->SetMarkerSize(1.3);
-    ymax=0; ymax=0;
-    for(int j=0; j<graph_plus1sigma->GetN(); j++){ 
-      if(graph_plus1sigma->GetY()[j]>ymax) {ymax=graph_plus1sigma->GetY()[j]; xmax=graph_plus1sigma->GetX()[j];}
-    }
-    graph_plus1sigma->Draw("AP");
-    if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_plus1sigma->Print(TString::Format("%s/%0.1f/tanb-CLs_860_%0.1f.png", directory, mass, mass));
-    else canv_plus1sigma->Print(TString::Format("%s/%d/tanb-CLs_860_%d.png", directory, (int)mass, (int)mass));
-    //plus2sigma
-    TCanvas* canv_plus2sigma = new TCanvas();
-    if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_plus2sigma = new TCanvas(TString::Format("tanb-CLs_975_%0.1f", mass), "", 600, 600);
-    else canv_plus2sigma = new TCanvas(TString::Format("tanb-CLs_975_%d", (int)mass), "", 600, 600);
-    canv_plus2sigma->cd();
-    canv_plus2sigma->SetGridx(1);
-    canv_plus2sigma->SetGridy(1);
-    graph_plus2sigma->GetXaxis()->SetTitle("tan#beta");
-    graph_plus2sigma->GetXaxis()->SetLabelFont(62);
-    graph_plus2sigma->GetXaxis()->SetTitleFont(62);
-    graph_plus2sigma->GetXaxis()->SetTitleColor(1);
-    graph_plus2sigma->GetXaxis()->SetTitleOffset(1.05);
-    graph_plus2sigma->GetYaxis()->SetTitle("CL_{s}");
-    graph_plus2sigma->GetYaxis()->SetLabelFont(62);
-    graph_plus2sigma->GetYaxis()->SetTitleFont(62);
-    graph_plus2sigma->GetYaxis()->SetTitleOffset(1.05);
-    graph_plus2sigma->GetYaxis()->SetLabelSize(0.03);
-    graph_plus2sigma->SetMarkerStyle(20);
-    graph_plus2sigma->SetMarkerSize(1.3);
-    ymax=0; ymax=0;
-    for(int j=0; j<graph_plus2sigma->GetN(); j++){ 
-      if(graph_plus2sigma->GetY()[j]>ymax) {ymax=graph_plus2sigma->GetY()[j]; xmax=graph_plus2sigma->GetX()[j];}
-    }
-    graph_plus2sigma->Draw("AP");
-    if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_plus2sigma->Print(TString::Format("%s/%0.1f/tanb-CLs_975_%0.1f.png", directory, mass, mass));
-    else canv_plus2sigma->Print(TString::Format("%s/%d/tanb-CLs_975_%d.png", directory, (int)mass, (int)mass));
-    //observed
-    TCanvas* canv_observed = new TCanvas();
-    if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_observed = new TCanvas(TString::Format("tanb-CLs_OBS_%0.1f", mass), "", 600, 600);
-    else canv_observed = new TCanvas(TString::Format("tanb-CLs_OBS_%d", (int)mass), "", 600, 600);
-    canv_observed->cd();
-    canv_observed->SetGridx(1);
-    canv_observed->SetGridy(1);
-    graph_observed->GetXaxis()->SetTitle("tan#beta");
-    graph_observed->GetXaxis()->SetLabelFont(62);
-    graph_observed->GetXaxis()->SetTitleFont(62);
-    graph_observed->GetXaxis()->SetTitleColor(1);
-    graph_observed->GetXaxis()->SetTitleOffset(1.05);
-    graph_observed->GetYaxis()->SetTitle("CL_{s}");
-    graph_observed->GetYaxis()->SetLabelFont(62);
-    graph_observed->GetYaxis()->SetTitleFont(62);
-    graph_observed->GetYaxis()->SetTitleOffset(1.05);
-    graph_observed->GetYaxis()->SetLabelSize(0.03);
-    graph_observed->SetMarkerStyle(20);
-    graph_observed->SetMarkerSize(1.3);
-    ymax=0; ymax=0;
-    for(int j=0; j<graph_observed->GetN(); j++){ 
-      if(graph_observed->GetY()[j]>ymax) {ymax=graph_observed->GetY()[j]; xmax=graph_observed->GetX()[j];}
-    }
-    graph_observed->Draw("AP");
-    if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_observed->Print(TString::Format("%s/%0.1f/tanb-CLs_OBS_%0.1f.png", directory, mass, mass));
-    else canv_observed->Print(TString::Format("%s/%d/tanb-CLs_OBS_%d.png", directory, (int)mass, (int)mass));
-    return;
+	//control plots showing the CLs value over tanb for each mass
+	//minus2sigma
+	TCanvas* canv_minus2sigma = new TCanvas();
+	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_minus2sigma = new TCanvas(TString::Format("tanb-CLs_025_%0.1f", mass), "", 600, 600);
+	else canv_minus2sigma = new TCanvas(TString::Format("tanb-CLs_025_%d", (int)mass), "", 600, 600);
+	canv_minus2sigma->cd();
+	canv_minus2sigma->SetGridx(1);
+	canv_minus2sigma->SetGridy(1);
+	graph_minus2sigma->SetMaximum(10);
+	graph_minus2sigma->GetXaxis()->SetTitle("tan#beta");
+	graph_minus2sigma->GetXaxis()->SetLabelFont(62);
+	graph_minus2sigma->GetXaxis()->SetTitleFont(62);
+	graph_minus2sigma->GetXaxis()->SetTitleColor(1);
+	graph_minus2sigma->GetXaxis()->SetTitleOffset(1.05);
+	graph_minus2sigma->GetYaxis()->SetTitle("CL_{s}");
+	graph_minus2sigma->GetYaxis()->SetLabelFont(62);
+	graph_minus2sigma->GetYaxis()->SetTitleFont(62);
+	graph_minus2sigma->GetYaxis()->SetTitleOffset(1.05);
+	graph_minus2sigma->GetYaxis()->SetLabelSize(0.03);
+	graph_minus2sigma->SetMarkerStyle(20);
+	graph_minus2sigma->SetMarkerSize(1.3);
+	ymax=0; ymax=0;
+	for(int j=0; j<graph_minus2sigma->GetN(); j++){ 
+		if(graph_minus2sigma->GetY()[j]>ymax) {ymax=graph_minus2sigma->GetY()[j]; xmax=graph_minus2sigma->GetX()[j];}
+	}
+	graph_minus2sigma->Draw("AP");
+	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_minus2sigma->Print(TString::Format("%s/%0.1f/tanb-CLs_025_%0.1f.png", directory, mass, mass));
+	else canv_minus2sigma->Print(TString::Format("%s/%d/tanb-CLs_025_%d.png", directory, (int)mass, (int)mass));
+	//minus1sigma
+	TCanvas* canv_minus1sigma = new TCanvas();
+	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_minus1sigma = new TCanvas(TString::Format("tanb-CLs_160_%0.1f", mass), "", 600, 600);
+	else canv_minus1sigma = new TCanvas(TString::Format("tanb-CLs_160_%d", (int)mass), "", 600, 600);
+	canv_minus1sigma->cd();
+	canv_minus1sigma->SetGridx(1);
+	canv_minus1sigma->SetGridy(1);
+	graph_minus1sigma->SetMaximum(10);
+	graph_minus1sigma->GetXaxis()->SetTitle("tan#beta");
+	graph_minus1sigma->GetXaxis()->SetLabelFont(62);
+	graph_minus1sigma->GetXaxis()->SetTitleFont(62);
+	graph_minus1sigma->GetXaxis()->SetTitleColor(1);
+	graph_minus1sigma->GetXaxis()->SetTitleOffset(1.05);
+	graph_minus1sigma->GetYaxis()->SetTitle("CL_{s}");
+	graph_minus1sigma->GetYaxis()->SetLabelFont(62);
+	graph_minus1sigma->GetYaxis()->SetTitleFont(62);
+	graph_minus1sigma->GetYaxis()->SetTitleOffset(1.05);
+	graph_minus1sigma->GetYaxis()->SetLabelSize(0.03);
+	graph_minus1sigma->SetMarkerStyle(20);
+	graph_minus1sigma->SetMarkerSize(1.3);
+	ymax=0; ymax=0;
+	for(int j=0; j<graph_minus1sigma->GetN(); j++){ 
+		if(graph_minus1sigma->GetY()[j]>ymax) {ymax=graph_minus1sigma->GetY()[j]; xmax=graph_minus1sigma->GetX()[j];}
+	}
+	graph_minus1sigma->Draw("AP");
+	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_minus1sigma->Print(TString::Format("%s/%0.1f/tanb-CLs_160_%0.1f.png", directory, mass, mass));
+	else canv_minus1sigma->Print(TString::Format("%s/%d/tanb-CLs_160_%d.png", directory, (int)mass, (int)mass));
+	//expected
+	TCanvas* canv_expected = new TCanvas();
+	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_expected = new TCanvas(TString::Format("tanb-CLs_EXP_%0.1f", mass), "", 600, 600);
+	else canv_expected = new TCanvas(TString::Format("tanb-CLs_EXP_%d", (int)mass), "", 600, 600);
+	canv_expected->cd();
+	canv_expected->SetGridx(1);
+	canv_expected->SetGridy(1);
+	graph_expected->SetMaximum(10);
+	graph_expected->GetXaxis()->SetTitle("tan#beta");
+	graph_expected->GetXaxis()->SetLabelFont(62);
+	graph_expected->GetXaxis()->SetTitleFont(62);
+	graph_expected->GetXaxis()->SetTitleColor(1);
+	graph_expected->GetXaxis()->SetTitleOffset(1.05);
+	graph_expected->GetYaxis()->SetTitle("CL_{s}");
+	graph_expected->GetYaxis()->SetLabelFont(62);
+	graph_expected->GetYaxis()->SetTitleFont(62);
+	graph_expected->GetYaxis()->SetTitleOffset(1.05);
+	graph_expected->GetYaxis()->SetLabelSize(0.03);
+	graph_expected->SetMarkerStyle(20);
+	graph_expected->SetMarkerSize(1.3);
+	ymax=0; ymax=0;
+	for(int j=0; j<graph_expected->GetN(); j++){ 
+		if(graph_expected->GetY()[j]>ymax) {ymax=graph_expected->GetY()[j]; xmax=graph_expected->GetX()[j];}
+	}
+	graph_expected->Draw("AP");
+	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_expected->Print(TString::Format("%s/%0.1f/tanb-CLs_EXP_%0.1f.png", directory, mass, mass));
+	else canv_expected->Print(TString::Format("%s/%d/tanb-CLs_EXP_%d.png", directory, (int)mass, (int)mass));
+	//plus1sigma
+	TCanvas* canv_plus1sigma = new TCanvas();
+	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_plus1sigma = new TCanvas(TString::Format("tanb-CLs_860_%0.1f", mass), "", 600, 600);
+	else canv_plus1sigma = new TCanvas(TString::Format("tanb-CLs_860_%d", (int)mass), "", 600, 600);
+	canv_plus1sigma->cd();
+	canv_plus1sigma->SetGridx(1);
+	canv_plus1sigma->SetGridy(1);
+	graph_plus1sigma->SetMaximum(10);
+	graph_plus1sigma->GetXaxis()->SetTitle("tan#beta");
+	graph_plus1sigma->GetXaxis()->SetLabelFont(62);
+	graph_plus1sigma->GetXaxis()->SetTitleFont(62);
+	graph_plus1sigma->GetXaxis()->SetTitleColor(1);
+	graph_plus1sigma->GetXaxis()->SetTitleOffset(1.05);
+	graph_plus1sigma->GetYaxis()->SetTitle("CL_{s}");
+	graph_plus1sigma->GetYaxis()->SetLabelFont(62);
+	graph_plus1sigma->GetYaxis()->SetTitleFont(62);
+	graph_plus1sigma->GetYaxis()->SetTitleOffset(1.05);
+	graph_plus1sigma->GetYaxis()->SetLabelSize(0.03);
+	graph_plus1sigma->SetMarkerStyle(20);
+	graph_plus1sigma->SetMarkerSize(1.3);
+	ymax=0; ymax=0;
+	for(int j=0; j<graph_plus1sigma->GetN(); j++){ 
+		if(graph_plus1sigma->GetY()[j]>ymax) {ymax=graph_plus1sigma->GetY()[j]; xmax=graph_plus1sigma->GetX()[j];}
+	}
+	graph_plus1sigma->Draw("AP");
+	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_plus1sigma->Print(TString::Format("%s/%0.1f/tanb-CLs_860_%0.1f.png", directory, mass, mass));
+	else canv_plus1sigma->Print(TString::Format("%s/%d/tanb-CLs_860_%d.png", directory, (int)mass, (int)mass));
+	//plus2sigma
+	TCanvas* canv_plus2sigma = new TCanvas();
+	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_plus2sigma = new TCanvas(TString::Format("tanb-CLs_975_%0.1f", mass), "", 600, 600);
+	else canv_plus2sigma = new TCanvas(TString::Format("tanb-CLs_975_%d", (int)mass), "", 600, 600);
+	canv_plus2sigma->cd();
+	canv_plus2sigma->SetGridx(1);
+	canv_plus2sigma->SetGridy(1);
+	graph_plus2sigma->SetMaximum(10);
+	graph_plus2sigma->GetXaxis()->SetTitle("tan#beta");
+	graph_plus2sigma->GetXaxis()->SetLabelFont(62);
+	graph_plus2sigma->GetXaxis()->SetTitleFont(62);
+	graph_plus2sigma->GetXaxis()->SetTitleColor(1);
+	graph_plus2sigma->GetXaxis()->SetTitleOffset(1.05);
+	graph_plus2sigma->GetYaxis()->SetTitle("CL_{s}");
+	graph_plus2sigma->GetYaxis()->SetLabelFont(62);
+	graph_plus2sigma->GetYaxis()->SetTitleFont(62);
+	graph_plus2sigma->GetYaxis()->SetTitleOffset(1.05);
+	graph_plus2sigma->GetYaxis()->SetLabelSize(0.03);
+	graph_plus2sigma->SetMarkerStyle(20);
+	graph_plus2sigma->SetMarkerSize(1.3);
+	ymax=0; ymax=0;
+	for(int j=0; j<graph_plus2sigma->GetN(); j++){ 
+		if(graph_plus2sigma->GetY()[j]>ymax) {ymax=graph_plus2sigma->GetY()[j]; xmax=graph_plus2sigma->GetX()[j];}
+	}
+	graph_plus2sigma->Draw("AP");
+	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_plus2sigma->Print(TString::Format("%s/%0.1f/tanb-CLs_975_%0.1f.png", directory, mass, mass));
+	else canv_plus2sigma->Print(TString::Format("%s/%d/tanb-CLs_975_%d.png", directory, (int)mass, (int)mass));
+	//observed
+	TCanvas* canv_observed = new TCanvas();
+	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_observed = new TCanvas(TString::Format("tanb-CLs_OBS_%0.1f", mass), "", 600, 600);
+	else canv_observed = new TCanvas(TString::Format("tanb-CLs_OBS_%d", (int)mass), "", 600, 600);
+	canv_observed->cd();
+	canv_observed->SetGridx(1);
+	canv_observed->SetGridy(1);
+	graph_observed->SetMaximum(10);
+	graph_observed->GetXaxis()->SetTitle("tan#beta");
+	graph_observed->GetXaxis()->SetLabelFont(62);
+	graph_observed->GetXaxis()->SetTitleFont(62);
+	graph_observed->GetXaxis()->SetTitleColor(1);
+	graph_observed->GetXaxis()->SetTitleOffset(1.05);
+	graph_observed->GetYaxis()->SetTitle("CL_{s}");
+	graph_observed->GetYaxis()->SetLabelFont(62);
+	graph_observed->GetYaxis()->SetTitleFont(62);
+	graph_observed->GetYaxis()->SetTitleOffset(1.05);
+	graph_observed->GetYaxis()->SetLabelSize(0.03);
+	graph_observed->SetMarkerStyle(20);
+	graph_observed->SetMarkerSize(1.3);
+	ymax=0; ymax=0;
+	for(int j=0; j<graph_observed->GetN(); j++){ 
+		if(graph_observed->GetY()[j]>ymax) {ymax=graph_observed->GetY()[j]; xmax=graph_observed->GetX()[j];}
+	}
+	graph_observed->Draw("AP");
+	if((model==TString::Format("2HDMtyp1") || model==TString::Format("2HDMtyp2"))&&(int)mass!=mass) canv_observed->Print(TString::Format("%s/%0.1f/tanb-CLs_OBS_%0.1f.png", directory, mass, mass));
+	else canv_observed->Print(TString::Format("%s/%d/tanb-CLs_OBS_%d.png", directory, (int)mass, (int)mass));
+	return;
 }
 

--- a/src/Tanb.cc
+++ b/src/Tanb.cc
@@ -505,7 +505,6 @@ void CLsControlPlots(TGraph* graph_minus2sigma, TGraph* graph_minus1sigma, TGrap
   canv_minus2sigma->cd();
   canv_minus2sigma->SetGridx(1);
   canv_minus2sigma->SetGridy(1);
-  graph_minus2sigma->SetMaximum(10);
   graph_minus2sigma->GetXaxis()->SetTitle("tan#beta");
   graph_minus2sigma->GetXaxis()->SetLabelFont(62);
   graph_minus2sigma->GetXaxis()->SetTitleFont(62);
@@ -532,7 +531,6 @@ void CLsControlPlots(TGraph* graph_minus2sigma, TGraph* graph_minus1sigma, TGrap
   canv_minus1sigma->cd();
   canv_minus1sigma->SetGridx(1);
   canv_minus1sigma->SetGridy(1);
-  graph_minus1sigma->SetMaximum(10);
   graph_minus1sigma->GetXaxis()->SetTitle("tan#beta");
   graph_minus1sigma->GetXaxis()->SetLabelFont(62);
   graph_minus1sigma->GetXaxis()->SetTitleFont(62);
@@ -559,7 +557,6 @@ void CLsControlPlots(TGraph* graph_minus2sigma, TGraph* graph_minus1sigma, TGrap
   canv_expected->cd();
   canv_expected->SetGridx(1);
   canv_expected->SetGridy(1);
-  graph_expected->SetMaximum(10);
   graph_expected->GetXaxis()->SetTitle("tan#beta");
   graph_expected->GetXaxis()->SetLabelFont(62);
   graph_expected->GetXaxis()->SetTitleFont(62);
@@ -586,7 +583,6 @@ void CLsControlPlots(TGraph* graph_minus2sigma, TGraph* graph_minus1sigma, TGrap
   canv_plus1sigma->cd();
   canv_plus1sigma->SetGridx(1);
   canv_plus1sigma->SetGridy(1);
-  graph_plus1sigma->SetMaximum(10);
   graph_plus1sigma->GetXaxis()->SetTitle("tan#beta");
   graph_plus1sigma->GetXaxis()->SetLabelFont(62);
   graph_plus1sigma->GetXaxis()->SetTitleFont(62);
@@ -613,7 +609,6 @@ void CLsControlPlots(TGraph* graph_minus2sigma, TGraph* graph_minus1sigma, TGrap
   canv_plus2sigma->cd();
   canv_plus2sigma->SetGridx(1);
   canv_plus2sigma->SetGridy(1);
-  graph_plus2sigma->SetMaximum(10);
   graph_plus2sigma->GetXaxis()->SetTitle("tan#beta");
   graph_plus2sigma->GetXaxis()->SetLabelFont(62);
   graph_plus2sigma->GetXaxis()->SetTitleFont(62);
@@ -640,7 +635,6 @@ void CLsControlPlots(TGraph* graph_minus2sigma, TGraph* graph_minus1sigma, TGrap
   canv_observed->cd();
   canv_observed->SetGridx(1);
   canv_observed->SetGridy(1);
-  graph_observed->SetMaximum(10);
   graph_observed->GetXaxis()->SetTitle("tan#beta");
   graph_observed->GetXaxis()->SetLabelFont(62);
   graph_observed->GetXaxis()->SetTitleFont(62);

--- a/src/contours2D.cxx
+++ b/src/contours2D.cxx
@@ -14,7 +14,7 @@
 #include "TH2D.h"
 #include "TPad.h"
 
-TH2D* frameTH2D(TH2D *in, double threshold);
+TH2D* frameTH2D(TH2D *in, double threshold,double mult);
 
 TGraph* bestFit(TTree *t, TString x, TString y, TCut cut) {
     int nfind = t->Draw(y+":"+x, cut + "deltaNLL == 0");
@@ -48,7 +48,7 @@ TH2 *treeToHist2D(TTree *t, TString x, TString y, TString name, TCut cut, double
     return h2d;
 }
 
-TList* contourFromTH2(TH2 *h2in, double threshold, int minPoints=20, bool require_minPoints=true) {
+TList* contourFromTH2(TH2 *h2in, double threshold, int minPoints=20, bool require_minPoints=true,double multip=1.) {
     std::cout << "Getting contour at threshold " << threshold << " from " << h2in->GetName() << std::endl;
     //http://root.cern.ch/root/html/tutorials/hist/ContourList.C.html
     Double_t contours[1];
@@ -56,7 +56,7 @@ TList* contourFromTH2(TH2 *h2in, double threshold, int minPoints=20, bool requir
     if (h2in->GetNbinsX() * h2in->GetNbinsY() > 10000) minPoints = 50;
     if (h2in->GetNbinsX() * h2in->GetNbinsY() <= 100) minPoints = 10;
 
-    TH2D *h2 = frameTH2D((TH2D*)h2in,threshold);
+    TH2D *h2 = frameTH2D((TH2D*)h2in,threshold,multip);
 
     h2->SetContour(1, contours);
 
@@ -89,7 +89,7 @@ TList* contourFromTH2(TH2 *h2in, double threshold, int minPoints=20, bool requir
     return ret;
 }
 
-TH2D* frameTH2D(TH2D *in, double threshold){
+TH2D* frameTH2D(TH2D *in, double threshold,double mult){
         // NEW LOGIC:
         //   - pretend that the center of the last bin is on the border of the frame
         //   - add one tiny frame with huge values
@@ -110,15 +110,15 @@ TH2D* frameTH2D(TH2D *in, double threshold){
         Double_t xbins[999], ybins[999]; 
         double eps = 0.01;
 
-        xbins[0] = x0 - eps*xw - xw; xbins[1] = x0 + eps*xw - xw;
+        xbins[0] = x0 - eps*xw - xw*mult; xbins[1] = x0 + eps*xw - xw*mult;
 	//xbins[0] = x0 - eps*xw - xw; xbins[1] = in->GetXaxis()->GetBinLowEdge(1);
 	for (int ix = 2; ix <= nx; ++ix) xbins[ix] = in->GetXaxis()->GetBinLowEdge(ix);
-        xbins[nx+1] = x1 - eps*xw + 0.5*xw; xbins[nx+2] = x1 + eps*xw + xw;
+        xbins[nx+1] = x1 - eps*xw + 0.5*xw*mult; xbins[nx+2] = x1 + eps*xw + xw*mult;
 	//xbins[nx+1] = in->GetXaxis()->GetBinLowEdge(nx+1); xbins[nx+2] = x1 + eps*xw + xw;
 
-        ybins[0] = y0 - eps*yw - yw; ybins[1] = y0 + eps*yw - yw;
+        ybins[0] = y0 - eps*yw - yw*mult; ybins[1] = y0 + eps*yw - yw*mult;
 	for (int iy = 2; iy <= ny; ++iy) ybins[iy] = in->GetYaxis()->GetBinLowEdge(iy);
-        ybins[ny+1] = y1 - eps*yw + yw; ybins[ny+2] = y1 + eps*yw + yw;
+        ybins[ny+1] = y1 - eps*yw + yw*mult; ybins[ny+2] = y1 + eps*yw + yw*mult;
         
 	TH2D *framed = new TH2D(
 			Form("%s framed",in->GetName()),

--- a/src/plottingTanb.cxx
+++ b/src/plottingTanb.cxx
@@ -292,30 +292,50 @@ plottingTanb(TCanvas& canv, TH2D* h2d, std::vector<TGraph*> minus2sigma, std::ve
 
 idx=0;
  for(std::map<double,std::vector<TGraph*>>::reverse_iterator band = higgsBandsLowTb.rbegin(); band!=higgsBandsLowTb.rend(); ++band, ++idx){
-   if(idx==1){
-for(unsigned int i=0;i<(band->second).size();i++){
-    (band->second)[i]->SetFillStyle(1001);
-    (band->second)[i]->SetLineStyle(3);
-    (band->second)[i]->SetFillColor(kWhite);
-    (band->second)[i]->SetLineColor(kGreen+3);
-    (band->second)[i]->SetLineWidth(-9902);
+}
+if(idx>1){
+ idx=0;
+ for(std::map<double,std::vector<TGraph*>>::iterator band = higgsBandsLowTb.begin();band!=higgsBandsLowTb.end(); ++band,++idx){
+   if(idx==0){
+    for(unsigned int i=0;i<(band->second).size();i++){
+      (band->second)[i]->SetFillStyle(1001);
+      (band->second)[i]->SetLineStyle(3);
+      (band->second)[i]->SetFillColor(kWhite);
+      (band->second)[i]->SetLineColor(kGreen+3);
+      (band->second)[i]->SetLineWidth(-9902);
 //    (band->second)[i]->Draw("F SAME");
-    (band->second)[i]->Draw("CONT SAME");
-}
- }
-  if(idx==0){
- for(unsigned int i=0;i<(band->second).size();i++){
-    (band->second)[i]->SetFillStyle(3005);
-    (band->second)[i]->SetFillColor(kRed);
-    (band->second)[i]->SetLineColor(kRed);
-    (band->second)[i]->SetLineWidth(-402);
-    (band->second)[i]->Draw("CONT SAME");
-}
- }
-
-
-
+      (band->second)[i]->Draw("L SAME");
+    }
    }
+
+  if(idx==1){
+    for(unsigned int i=0;i<(band->second).size();i++){
+      (band->second)[i]->SetFillStyle(3005);
+      (band->second)[i]->SetFillColor(kRed);
+      (band->second)[i]->SetLineColor(kRed);
+      (band->second)[i]->SetLineWidth(-402);
+      (band->second)[i]->Draw("L SAME");
+       }
+     }
+   }
+ }
+
+ else{
+ idx=0;
+ for(std::map<double,std::vector<TGraph*>>::iterator band = higgsBandsLowTb.begin();band!=higgsBandsLowTb.end(); ++band,++idx){
+   if(idx==0){
+    for(unsigned int i=0;i<(band->second).size();i++){
+      (band->second)[i]->SetFillStyle(3005);
+      (band->second)[i]->SetFillColor(kRed);
+      (band->second)[i]->SetLineColor(kRed);
+      (band->second)[i]->SetLineWidth(-402);
+      (band->second)[i]->Draw("L SAME");
+       }
+     }
+   }
+}
+ 
+
 
 
 

--- a/src/plottingTanb.cxx
+++ b/src/plottingTanb.cxx
@@ -213,6 +213,7 @@ plottingTanb(TCanvas& canv, TH2D* h2d, std::vector<TGraph*> minus2sigma, std::ve
   //background->Draw("3"); 
 
   //exclusion graphs
+
   for(unsigned int i=0; i<minus2sigma.size(); i++){
     minus2sigma[i]->SetFillStyle(1001);
     minus2sigma[i]->SetFillColor(twosigma->GetNumber()); 
@@ -252,7 +253,7 @@ plottingTanb(TCanvas& canv, TH2D* h2d, std::vector<TGraph*> minus2sigma, std::ve
     expected[i]->SetLineColor(kBlack); 
     expected[i]->SetLineWidth(2);
     expected[i]->SetLineStyle(2); 
-    expected[i]->Draw("CONT SAME");
+    expected[i]->Draw("L SAME");
   }  
 
   if(injected[0]){
@@ -276,7 +277,7 @@ plottingTanb(TCanvas& canv, TH2D* h2d, std::vector<TGraph*> minus2sigma, std::ve
       if(Brazilian) observed[i]->SetFillColor(kBlack); 
       if(Brazilian) observed[i]->SetFillStyle(3004);  
       observed[i]->Draw("F SAME"); 
-      observed[i]->Draw("CONT SAME"); 
+      observed[i]->Draw("L SAME"); 
     } 
   }
   if(connection_min2) connection_min2->Draw("Lsame");
@@ -353,15 +354,18 @@ for(unsigned int i=0;i<(band->second).size();i++){
     else if(theory=="MSSM m_{h}^{mod+} scenario") theory1= new TPaveText(0.59, 0.20, 0.91, 0.26, "NDC"); 
     else if(theory=="MSSM light-stop scenario") theory1= new TPaveText(0.51, 0.20, 0.91, 0.26, "NDC"); //for loglog
     else if(theory=="MSSM light-stau scenario") theory1= new TPaveText(0.51, 0.20, 0.91, 0.26, "NDC");
-    else if(theory=="MSSM low-tan#beta-high scenario") theory1 = new TPaveText(0.15, 0.85, 0.61, 0.91, "NDC"); //(0.45, 0.75, 0.91, 0.81, "NDC")Hhh
+    else if(theory=="MSSM low-tan#beta-high scenario") theory1 = new TPaveText(0.15, 0.80, 0.55, 0.91, "NDC"); //(0.45, 0.75, 0.91, 0.81, "NDC")Hhh
     else if(theory=="2HDM type-I") theory1 = new TPaveText(0.65, 0.20, 0.91, 0.26, "NDC");
-    else if(theory=="2HDM type-II") theory1 = new TPaveText(0.65, 0.20, 0.91, 0.26, "NDC");
+    else if(theory=="2HDM type-II") theory1 = new TPaveText(0.45, 0.50, 0.75, 0.56, "NDC");
     else theory1= new TPaveText(0.51, 0.20, 0.91, 0.26, "NDC");
   }
   theory1->SetBorderSize(   0 );
   theory1->SetFillStyle(    0 );
   theory1->SetTextAlign(   12 );
+  if(theory=="MSSM low-tan#beta-high scenario") theory1->SetTextSize(0.030);
+  else{
   theory1->SetTextSize ( 0.035);
+ }
   theory1->SetTextColor(    1 );
   theory1->SetTextFont (   62 );
   theory1->AddText(theory.c_str());
@@ -385,9 +389,9 @@ for(unsigned int i=0;i<(band->second).size();i++){
     }
     else{
       if(theory=="MSSM low-m_{H} scenario") leg = new TLegend(0.175, 0.155, 0.62, 0.30);
-      else if(theory=="MSSM low-tan#beta-high scenario") leg = new TLegend(0.58, 0.54, 0.90, 0.84); //(0.18, 0.59, 0.45, 0.89)Hhh 
+      else if(theory=="MSSM low-tan#beta-high scenario") leg = new TLegend(0.58, 0.58, 0.90, 0.88); //(0.18, 0.59, 0.45, 0.89)Hhh 
       else if(theory=="MSSM light-stop scenario") leg = new TLegend(0.28, (!higgsBands.empty() || !comparisons.empty()) ? 0.57 :0.69, (!higgsBands.empty() || !comparisons.empty()) ? 0.53: 0.56, 0.89);
-      else if(theory=="2HDM type-I" || theory=="2HDM type-II") leg = new TLegend(0.43, 0.19, 0.45, 0.89); 
+      else if(theory=="2HDM type-I" || theory=="2HDM type-II") leg = new TLegend(0.42, 0.59, 0.75, 0.89); 
       else leg = new TLegend(0.23, (!higgsBands.empty() || !comparisons.empty()) ? 0.57 : 0.69, (!higgsBands.empty() || !comparisons.empty()) ? 0.47: 0.50, 0.89);
     }
   }
@@ -438,13 +442,14 @@ for(unsigned int i=0;i<(band->second).size();i++){
   }
   else{ 
     if(theory=="MSSM low-m_{H} scenario") leg2 = new TLegend(0.57, 0.78, 0.92, 0.83);
-    else if(theory=="MSSM low-tan#beta-high scenario"&&!azh) leg2 = new TLegend(0.52, 0.45, 0.92, 0.53);//(0.57, 0.81, 0.92, 0.86)Hhh
-    else if(theory=="MSSM low-tan#beta-high scenario") leg2 = new TLegend(0.17,0.58,0.52,0.63);
+    else if(theory=="MSSM low-tan#beta-high scenario"&&!azh) leg2 = new TLegend(0.17,0.75,0.52,0.83);
+    else if(theory=="MSSM low-tan#beta-high scenario") leg2 = new TLegend(0.17,0.78,0.52,0.83);
     else leg2 = new TLegend(0.57, 0.26, 0.92, 0.31);
   }  
   leg2->SetBorderSize( 1  );
   leg2->SetFillStyle (1001);
-  leg2->SetTextSize  (0.03);
+  if(!azh) leg2->SetTextSize  (0.027);
+  else leg2->SetTextSize(0.03);
   leg2->SetTextFont  ( 62 ); 
   leg2->SetFillColor (kWhite);
   leg2->SetLineWidth (2);


### PR DESCRIPTION
-For applying xs*br to H->hh+A->Zh combination, added an extra channel ("HhhAndAZh") to ModelDatacard and ModelParams_Base
- TGraph2D interpolation for contour extraction now supported- needs to be called as option in layout files (graphInterpolate=cms.bool(True) )
- Added layout files for A->Zh, H->hh, and combination in low tb high and 2HDM scenarios
- The large number of removed and added lines in Tanb.cc is a result of slightly too aggressive use of automatic indentation