### PR TITLE
added return value map<datacard.txt, mass_set> to CardWriter::WriteCards

### DIFF
--- a/CombineHarvester/CombineTools/interface/CardWriter.h
+++ b/CombineHarvester/CombineTools/interface/CardWriter.h
@@ -52,7 +52,7 @@ class CardWriter {
   /// Must be constructed with text and ROOT file patterns
   CardWriter(std::string const& text_pattern, std::string const& root_pattern);
   /// Write datacards according to patterns, substituting `$TAG` for `tag`
-  void WriteCards(std::string const& tag, ch::CombineHarvester& cmb) const;
+  std::map<std::string, std::set<std::string> > WriteCards(std::string const& tag, ch::CombineHarvester& cmb) const;
   /// Set >= 1 for verbose output, otherwise silent
   CardWriter& SetVerbosity(unsigned v);
   /// Control whether directories can be created if missing

--- a/CombineHarvester/CombineTools/interface/CardWriter.h
+++ b/CombineHarvester/CombineTools/interface/CardWriter.h
@@ -52,7 +52,7 @@ class CardWriter {
   /// Must be constructed with text and ROOT file patterns
   CardWriter(std::string const& text_pattern, std::string const& root_pattern);
   /// Write datacards according to patterns, substituting `$TAG` for `tag`
-  std::map<std::string, std::set<std::string> > WriteCards(std::string const& tag, ch::CombineHarvester& cmb) const;
+  std::map<std::string, CombineHarvester> WriteCards(std::string const& tag, ch::CombineHarvester& cmb) const;
   /// Set >= 1 for verbose output, otherwise silent
   CardWriter& SetVerbosity(unsigned v);
   /// Control whether directories can be created if missing

--- a/CombineHarvester/CombineTools/interface/CombineHarvester_Python.h
+++ b/CombineHarvester/CombineTools/interface/CombineHarvester_Python.h
@@ -65,17 +65,13 @@ struct convert_cpp_set_to_py_list {
 };
 
 /**
- * Convert a C++ map<TKey, std::set<TValue> to a python dict
+ * Convert a C++ map to a python dict
  */
 template <typename TKey, typename TValue>
-struct convert_cpp_set_map_to_py_list_dict {
-  static PyObject* convert(const std::map<TKey, std::set<TValue>>& in) {
+struct convert_cpp_map_to_py_dict {
+  static PyObject* convert(const std::map<TKey, TValue>& in) {
     bp::dict out;
-    for (std::pair<TKey, std::set<TValue>> const& ele : in) {
-      bp::list value;
-      for (TValue const& val : ele.second) value.append(val);
-      out[ele.first] = value;
-    }
+    for (std::pair<TKey, TValue> const& ele : in) out[ele.first] = ele.second;
     return bp::incref(out.ptr());
   }
 };

--- a/CombineHarvester/CombineTools/interface/CombineHarvester_Python.h
+++ b/CombineHarvester/CombineTools/interface/CombineHarvester_Python.h
@@ -1,5 +1,6 @@
 #include <vector>
 #include <set>
+#include <map>
 #include "boost/python.hpp"
 #include "boost/python/type_id.hpp"
 #include "TPython.h"
@@ -59,6 +60,22 @@ struct convert_cpp_set_to_py_list {
   static PyObject* convert(const std::set<T>& in) {
     bp::list out;
     for (T const& ele : in) out.append(ele);
+    return bp::incref(out.ptr());
+  }
+};
+
+/**
+ * Convert a C++ map<TKey, std::set<TValue> to a python dict
+ */
+template <typename TKey, typename TValue>
+struct convert_cpp_set_map_to_py_list_dict {
+  static PyObject* convert(const std::map<TKey, std::set<TValue>>& in) {
+    bp::dict out;
+    for (std::pair<TKey, std::set<TValue>> const& ele : in) {
+      bp::list value;
+      for (TValue const& val : ele.second) value.append(val);
+      out[ele.first] = value;
+    }
     return bp::incref(out.ptr());
   }
 };

--- a/CombineHarvester/CombineTools/src/CardWriter.cc
+++ b/CombineHarvester/CombineTools/src/CardWriter.cc
@@ -71,7 +71,7 @@ void CardWriter::MakeDirs(PatternMap const& map) const {
   }
 }
 
-std::map<std::string, std::set<std::string> > CardWriter::WriteCards(std::string const& tag,
+std::map<std::string, CombineHarvester> CardWriter::WriteCards(std::string const& tag,
                        ch::CombineHarvester& cmb) const {
   #ifdef TIME_FUNCTIONS
     LAUNCH_FUNCTION_TIMER(__timer__, __token__)
@@ -107,7 +107,7 @@ std::map<std::string, std::set<std::string> > CardWriter::WriteCards(std::string
       text_map[obj] = Compile(text_pattern_, obj);
     });
 
-  std::map<std::string, std::set<std::string> > datacards;
+  std::map<std::string, CombineHarvester> datacards;
   for (auto const& f : f_map) {
     // Create each ROOT file (overwrite pre-existing)
     FNLOGC(std::cout, v_ > 0) << "Creating file " << f.first << "\n";
@@ -135,7 +135,7 @@ std::map<std::string, std::set<std::string> > CardWriter::WriteCards(std::string
       });
       FNLOGC(std::cout, v_ > 0) << "Creating datacard " << d.first << "\n";
       d_cmb.WriteDatacard(d.first, file);
-      datacards[d.first] = d_cmb.mass_set();
+      datacards[d.first] = d_cmb;
     }
   };
   return datacards;

--- a/CombineHarvester/CombineTools/src/CardWriter.cc
+++ b/CombineHarvester/CombineTools/src/CardWriter.cc
@@ -71,7 +71,7 @@ void CardWriter::MakeDirs(PatternMap const& map) const {
   }
 }
 
-void CardWriter::WriteCards(std::string const& tag,
+std::map<std::string, std::set<std::string> > CardWriter::WriteCards(std::string const& tag,
                        ch::CombineHarvester& cmb) const {
   #ifdef TIME_FUNCTIONS
     LAUNCH_FUNCTION_TIMER(__timer__, __token__)
@@ -107,6 +107,7 @@ void CardWriter::WriteCards(std::string const& tag,
       text_map[obj] = Compile(text_pattern_, obj);
     });
 
+  std::map<std::string, std::set<std::string> > datacards;
   for (auto const& f : f_map) {
     // Create each ROOT file (overwrite pre-existing)
     FNLOGC(std::cout, v_ > 0) << "Creating file " << f.first << "\n";
@@ -134,8 +135,10 @@ void CardWriter::WriteCards(std::string const& tag,
       });
       FNLOGC(std::cout, v_ > 0) << "Creating datacard " << d.first << "\n";
       d_cmb.WriteDatacard(d.first, file);
+      datacards[d.first] = d_cmb.mass_set();
     }
   };
+  return datacards;
 }
 
 std::string CardWriter::Compile(std::string pattern, ch::Object const* obj,

--- a/CombineHarvester/CombineTools/src/CombineHarvester_Python.pycc
+++ b/CombineHarvester/CombineTools/src/CombineHarvester_Python.pycc
@@ -163,8 +163,8 @@ BOOST_PYTHON_MODULE(_combineharvester)
   py::to_python_converter<std::set<int>,
                           convert_cpp_set_to_py_list<int>>();
 
-  py::to_python_converter<std::map<std::string, std::set<std::string>>,
-                          convert_cpp_set_map_to_py_list_dict<std::string, std::string>>();
+  py::to_python_converter<std::map<std::string, CombineHarvester>,
+                          convert_cpp_map_to_py_dict<std::string, CombineHarvester>>();
 
   py::to_python_converter<TH1F,
                           convert_cpp_root_to_py_root<TH1F>>();

--- a/CombineHarvester/CombineTools/src/CombineHarvester_Python.pycc
+++ b/CombineHarvester/CombineTools/src/CombineHarvester_Python.pycc
@@ -163,6 +163,9 @@ BOOST_PYTHON_MODULE(_combineharvester)
   py::to_python_converter<std::set<int>,
                           convert_cpp_set_to_py_list<int>>();
 
+  py::to_python_converter<std::map<std::string, std::set<std::string>>,
+                          convert_cpp_set_map_to_py_list_dict<std::string, std::string>>();
+
   py::to_python_converter<TH1F,
                           convert_cpp_root_to_py_root<TH1F>>();
 


### PR DESCRIPTION
Hi Andrew,

do you think, we can add a return value to the CardWriter::WriteCards function that would contain a map with the datacard filename as a key and the set of masses as a value? (Maybe in practice it will alwas be only mass point plus "*", such that a map<string, string> would be sufficient?) This function would then ease the calls of text2workspace.py since the filenames and masses are then known.

Cheers,
Thomas